### PR TITLE
feat: ジャンル並び替え機能v2の実装

### DIFF
--- a/__tests__/integration/genre-order-integration.test.tsx
+++ b/__tests__/integration/genre-order-integration.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SettingsModal } from '@/components/settings-modal'
+import { vi } from 'vitest'
+
+// Mock hooks
+vi.mock('@/hooks/use-user-ng-list', () => ({
+  useUserNGList: () => ({
+    ngList: {
+      videoIds: [],
+      videoTitles: { exact: [], partial: [] },
+      authorIds: [],
+      authorNames: { exact: [], partial: [] },
+      totalCount: 0
+    },
+    saveNGListDirectly: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/use-user-preferences', () => ({
+  useUserPreferences: () => ({
+    preferences: { theme: 'light' },
+    updatePreferences: vi.fn()
+  })
+}))
+
+// Mock window.location.reload
+const reloadMock = vi.fn()
+Object.defineProperty(window, 'location', {
+  value: { reload: reloadMock },
+  writable: true
+})
+
+describe('Genre Order Integration', () => {
+  beforeEach(() => {
+    reloadMock.mockClear()
+  })
+
+  it('shows genre order tab in settings modal', () => {
+    render(<SettingsModal isOpen={true} onClose={() => {}} />)
+    
+    const genreOrderTab = screen.getByText('🎯 ジャンル並び替え')
+    expect(genreOrderTab).toBeInTheDocument()
+  })
+
+  it('displays genre order customizer when tab is clicked', () => {
+    render(<SettingsModal isOpen={true} onClose={() => {}} />)
+    
+    const genreOrderTab = screen.getByText('🎯 ジャンル並び替え')
+    fireEvent.click(genreOrderTab)
+    
+    // Check for customizer content
+    expect(screen.getByText(/ドラッグ&ドロップでジャンルの順序を変更/)).toBeInTheDocument()
+    expect(screen.getByText('デフォルトに戻す')).toBeInTheDocument()
+  })
+
+  it('shows apply button when changes are made', async () => {
+    render(<SettingsModal isOpen={true} onClose={() => {}} />)
+    
+    // Navigate to genre order tab
+    const genreOrderTab = screen.getByText('🎯 ジャンル並び替え')
+    fireEvent.click(genreOrderTab)
+    
+    // Initially no apply button
+    expect(screen.queryByText('適用')).not.toBeInTheDocument()
+    
+    // Click default reset button
+    const resetButton = screen.getByText('デフォルトに戻す')
+    fireEvent.click(resetButton)
+    
+    // Apply button should appear
+    await waitFor(() => {
+      expect(screen.getByText('適用')).toBeInTheDocument()
+    })
+  })
+
+  it('applies changes and reloads when apply is clicked', async () => {
+    render(<SettingsModal isOpen={true} onClose={() => {}} />)
+    
+    // Navigate to genre order tab
+    const genreOrderTab = screen.getByText('🎯 ジャンル並び替え')
+    fireEvent.click(genreOrderTab)
+    
+    // Make a change
+    const resetButton = screen.getByText('デフォルトに戻す')
+    fireEvent.click(resetButton)
+    
+    // Click apply
+    await waitFor(() => {
+      const applyButton = screen.getByText('適用')
+      fireEvent.click(applyButton)
+    })
+    
+    // Should reload
+    expect(reloadMock).toHaveBeenCalled()
+  })
+
+  it('confirms before closing with unsaved changes', async () => {
+    const confirmMock = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const onClose = vi.fn()
+    
+    render(<SettingsModal isOpen={true} onClose={onClose} />)
+    
+    // Navigate to genre order tab
+    const genreOrderTab = screen.getByText('🎯 ジャンル並び替え')
+    fireEvent.click(genreOrderTab)
+    
+    // Make a change
+    const resetButton = screen.getByText('デフォルトに戻す')
+    fireEvent.click(resetButton)
+    
+    // Try to close
+    const closeButton = screen.getByText('閉じる')
+    fireEvent.click(closeButton)
+    
+    // Should confirm
+    expect(confirmMock).toHaveBeenCalledWith('変更を破棄してもよろしいですか？')
+    expect(onClose).not.toHaveBeenCalled()
+    
+    confirmMock.mockRestore()
+  })
+})

--- a/__tests__/unit/components/mobile-hover-fix.test.tsx
+++ b/__tests__/unit/components/mobile-hover-fix.test.tsx
@@ -40,17 +40,17 @@ describe('RankingItemResponsive - モバイルホバー修正', () => {
     test('タッチ終了時のイベントハンドリング', () => {
       vi.useFakeTimers()
       const { container } = render(<RankingItemResponsive item={mockItem} />)
-      const listItem = container.querySelector('li')!
+      const rankingItem = container.querySelector('.ranking-item-responsive')!
       
       // タッチ終了イベントが処理されることを確認
       const touchEndEvent = new TouchEvent('touchend', { bubbles: true })
-      listItem.dispatchEvent(touchEndEvent)
+      rankingItem.dispatchEvent(touchEndEvent)
       
       // タイマーが動作することを確認
       vi.advanceTimersByTime(100)
       
       // エラーが発生しないことを確認（実際の値は環境依存）
-      expect(listItem).toBeInTheDocument()
+      expect(rankingItem).toBeInTheDocument()
       
       vi.useRealTimers()
     })

--- a/__tests__/unit/genre-order-backup.test.tsx
+++ b/__tests__/unit/genre-order-backup.test.tsx
@@ -61,6 +61,7 @@ describe('GenreOrderBackup', () => {
 
   it('imports data when confirm button is clicked in dialog', async () => {
     vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const reloadSpy = vi.fn()
     Object.defineProperty(window, 'location', {
       value: { reload: reloadSpy },
@@ -110,10 +111,13 @@ describe('GenreOrderBackup', () => {
     
     expect(setItemSpy).toHaveBeenCalledWith('nicoRankingGenreOrder', JSON.stringify(validData.genreOrder))
     
-    // Wait for reload timeout
+    // Wait for reload confirmation dialog
     await waitFor(() => {
-      expect(reloadSpy).toHaveBeenCalled()
-    }, { timeout: 3500 })
+      expect(confirmSpy).toHaveBeenCalledWith('インポートが完了しました。ページをリロードして変更を反映しますか？')
+    }, { timeout: 2000 })
+    
+    // Check reload was called
+    expect(reloadSpy).toHaveBeenCalled()
   })
 
   it('cancels import when cancel button is clicked in dialog', async () => {
@@ -174,5 +178,66 @@ describe('GenreOrderBackup', () => {
     await waitFor(() => {
       expect(screen.getByText('無効なバックアップファイル形式です')).toBeInTheDocument()
     })
+  })
+
+  it('does not reload when user cancels reload confirmation', async () => {
+    vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadSpy },
+      writable: true
+    })
+    
+    // Mock localStorage
+    const setItemSpy = vi.fn()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        setItem: setItemSpy,
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn()
+      },
+      writable: true
+    })
+    
+    render(<GenreOrderBackup />)
+    
+    const validData = {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      genreOrder: [
+        { id: 'game', isVisible: true, order: 0 },
+        { id: 'all', isVisible: false, order: 1 },
+      ]
+    }
+    
+    const file = new File([JSON.stringify(validData)], 'backup.json', { type: 'application/json' })
+    const input = screen.getByTestId('import-file-input') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { files: [file] } })
+    
+    // 確認ダイアログが表示されるのを待つ
+    await waitFor(() => {
+      expect(screen.getByTestId('import-confirm-dialog')).toBeInTheDocument()
+    })
+    
+    // インポート実行ボタンをクリック
+    const confirmButton = screen.getByText('インポート実行')
+    fireEvent.click(confirmButton)
+    
+    await waitFor(() => {
+      expect(screen.getByText(/ジャンル並び替えデータをインポートしました/)).toBeInTheDocument()
+    })
+    
+    expect(setItemSpy).toHaveBeenCalledWith('nicoRankingGenreOrder', JSON.stringify(validData.genreOrder))
+    
+    // Wait for reload confirmation dialog
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalledWith('インポートが完了しました。ページをリロードして変更を反映しますか？')
+    }, { timeout: 2000 })
+    
+    // Check reload was NOT called
+    expect(reloadSpy).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/unit/genre-order-backup.test.tsx
+++ b/__tests__/unit/genre-order-backup.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { GenreOrderBackup } from '@/components/genre-order-backup'
+import { vi } from 'vitest'
+
+// Mock useGenreOrderV2
+vi.mock('@/hooks/use-genre-order-v2', () => ({
+  useGenreOrderV2: () => ({
+    items: [
+      { id: 'all', isVisible: true, order: 0 },
+      { id: 'game', isVisible: true, order: 1 },
+      { id: 'anime', isVisible: false, order: 2 },
+    ]
+  })
+}))
+
+describe('GenreOrderBackup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders export and import buttons', () => {
+    render(<GenreOrderBackup />)
+    
+    expect(screen.getByText('📥 エクスポート')).toBeInTheDocument()
+    expect(screen.getByText('📤 インポート')).toBeInTheDocument()
+  })
+
+  it('renders usage instructions', () => {
+    render(<GenreOrderBackup />)
+    
+    expect(screen.getByText('📌 使い方:')).toBeInTheDocument()
+    expect(screen.getByText(/エクスポート: 現在のジャンル並び替え設定をファイルに保存します/)).toBeInTheDocument()
+    expect(screen.getByText(/インポート: 保存したファイルから設定を復元します/)).toBeInTheDocument()
+  })
+
+  it('shows success message when valid file is imported', async () => {
+    vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadSpy },
+      writable: true
+    })
+    
+    // Mock localStorage
+    const setItemSpy = vi.fn()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        setItem: setItemSpy,
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn()
+      },
+      writable: true
+    })
+    
+    render(<GenreOrderBackup />)
+    
+    const validData = {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      genreOrder: [
+        { id: 'game', isVisible: true, order: 0 },
+        { id: 'all', isVisible: false, order: 1 },
+      ]
+    }
+    
+    const file = new File([JSON.stringify(validData)], 'backup.json', { type: 'application/json' })
+    const input = screen.getByLabelText('📤 インポート').parentElement?.querySelector('input[type="file"]') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { files: [file] } })
+    
+    await waitFor(() => {
+      expect(screen.getByText(/ジャンル並び替えデータをインポートしました/)).toBeInTheDocument()
+    })
+    
+    expect(setItemSpy).toHaveBeenCalledWith('nicoRankingGenreOrder', JSON.stringify(validData.genreOrder))
+    
+    // Wait for reload timeout
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalled()
+    }, { timeout: 3500 })
+  })
+
+  it('shows error message for invalid file format', async () => {
+    render(<GenreOrderBackup />)
+    
+    const invalidData = { invalid: 'data' }
+    const file = new File([JSON.stringify(invalidData)], 'invalid.json', { type: 'application/json' })
+    const input = screen.getByLabelText('📤 インポート').parentElement?.querySelector('input[type="file"]') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { files: [file] } })
+    
+    await waitFor(() => {
+      expect(screen.getByText('無効なバックアップファイル形式です')).toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/unit/genre-order-backup.test.tsx
+++ b/__tests__/unit/genre-order-backup.test.tsx
@@ -22,8 +22,8 @@ describe('GenreOrderBackup', () => {
   it('renders export and import buttons', () => {
     render(<GenreOrderBackup />)
     
-    expect(screen.getByText('📥 エクスポート')).toBeInTheDocument()
-    expect(screen.getByText('📤 インポート')).toBeInTheDocument()
+    expect(screen.getByText('エクスポート')).toBeInTheDocument()
+    expect(screen.getByText('インポート')).toBeInTheDocument()
   })
 
   it('renders usage instructions', () => {
@@ -34,7 +34,32 @@ describe('GenreOrderBackup', () => {
     expect(screen.getByText(/インポート: 保存したファイルから設定を復元します/)).toBeInTheDocument()
   })
 
-  it('shows success message when valid file is imported', async () => {
+  it('shows import confirmation dialog when valid file is imported', async () => {
+    render(<GenreOrderBackup />)
+    
+    const validData = {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      genreOrder: [
+        { id: 'game', isVisible: true, order: 0 },
+        { id: 'all', isVisible: false, order: 1 },
+      ]
+    }
+    
+    const file = new File([JSON.stringify(validData)], 'backup.json', { type: 'application/json' })
+    const input = screen.getByTestId('import-file-input') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { files: [file] } })
+    
+    // 確認ダイアログが表示されることを確認
+    await waitFor(() => {
+      expect(screen.getByTestId('import-confirm-dialog')).toBeInTheDocument()
+      expect(screen.getByText('ジャンル並び替えデータをインポート')).toBeInTheDocument()
+      expect(screen.getByText(/現在のジャンル並び替え設定は完全に上書きされます/)).toBeInTheDocument()
+    })
+  })
+
+  it('imports data when confirm button is clicked in dialog', async () => {
     vi.spyOn(window, 'alert').mockImplementation(() => {})
     const reloadSpy = vi.fn()
     Object.defineProperty(window, 'location', {
@@ -66,9 +91,18 @@ describe('GenreOrderBackup', () => {
     }
     
     const file = new File([JSON.stringify(validData)], 'backup.json', { type: 'application/json' })
-    const input = screen.getByLabelText('📤 インポート').parentElement?.querySelector('input[type="file"]') as HTMLInputElement
+    const input = screen.getByTestId('import-file-input') as HTMLInputElement
     
     fireEvent.change(input, { target: { files: [file] } })
+    
+    // 確認ダイアログが表示されるのを待つ
+    await waitFor(() => {
+      expect(screen.getByTestId('import-confirm-dialog')).toBeInTheDocument()
+    })
+    
+    // インポート実行ボタンをクリック
+    const confirmButton = screen.getByText('インポート実行')
+    fireEvent.click(confirmButton)
     
     await waitFor(() => {
       expect(screen.getByText(/ジャンル並び替えデータをインポートしました/)).toBeInTheDocument()
@@ -82,12 +116,58 @@ describe('GenreOrderBackup', () => {
     }, { timeout: 3500 })
   })
 
+  it('cancels import when cancel button is clicked in dialog', async () => {
+    const setItemSpy = vi.fn()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        setItem: setItemSpy,
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn()
+      },
+      writable: true
+    })
+    
+    render(<GenreOrderBackup />)
+    
+    const validData = {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      genreOrder: [
+        { id: 'game', isVisible: true, order: 0 },
+        { id: 'all', isVisible: false, order: 1 },
+      ]
+    }
+    
+    const file = new File([JSON.stringify(validData)], 'backup.json', { type: 'application/json' })
+    const input = screen.getByTestId('import-file-input') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { files: [file] } })
+    
+    // 確認ダイアログが表示されるのを待つ
+    await waitFor(() => {
+      expect(screen.getByTestId('import-confirm-dialog')).toBeInTheDocument()
+    })
+    
+    // キャンセルボタンをクリック
+    const cancelButton = screen.getByText('キャンセル')
+    fireEvent.click(cancelButton)
+    
+    // ダイアログが閉じることを確認
+    await waitFor(() => {
+      expect(screen.queryByTestId('import-confirm-dialog')).not.toBeInTheDocument()
+    })
+    
+    // LocalStorageに保存されていないことを確認
+    expect(setItemSpy).not.toHaveBeenCalled()
+  })
+
   it('shows error message for invalid file format', async () => {
     render(<GenreOrderBackup />)
     
     const invalidData = { invalid: 'data' }
     const file = new File([JSON.stringify(invalidData)], 'invalid.json', { type: 'application/json' })
-    const input = screen.getByLabelText('📤 インポート').parentElement?.querySelector('input[type="file"]') as HTMLInputElement
+    const input = screen.getByTestId('import-file-input') as HTMLInputElement
     
     fireEvent.change(input, { target: { files: [file] } })
     

--- a/__tests__/unit/genre-order-v2.test.tsx
+++ b/__tests__/unit/genre-order-v2.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { GenreOrderCustomizer } from '@/components/genre-order'
+import { vi } from 'vitest'
+import type { RankingGenre } from '@/types/ranking-config'
+
+// Mock the hook
+vi.mock('@/hooks/use-genre-order-v2', () => ({
+  useGenreOrderV2: () => ({
+    items: [
+      { id: 'all' as RankingGenre, isVisible: true, order: 0 },
+      { id: 'game' as RankingGenre, isVisible: true, order: 1 },
+      { id: 'anime' as RankingGenre, isVisible: false, order: 2 },
+      { id: 'vocaloid' as RankingGenre, isVisible: true, order: 3 },
+    ],
+    visibleGenres: ['all', 'game', 'vocaloid'] as RankingGenre[],
+    hiddenGenres: ['anime'] as RankingGenre[],
+    hasChanges: false,
+    swapItems: vi.fn(),
+    toggleVisibility: vi.fn(),
+    resetToDefault: vi.fn(),
+    applyChanges: vi.fn(),
+    cancelChanges: vi.fn()
+  })
+}))
+
+// Mock GENRE_LABELS
+vi.mock('@/types/ranking-config', () => ({
+  GENRE_LABELS: {
+    all: '総合',
+    game: 'ゲーム',
+    anime: 'アニメ',
+    vocaloid: 'ボカロ'
+  }
+}))
+
+describe('GenreOrderCustomizer v2', () => {
+  it('renders all genres correctly', () => {
+    render(<GenreOrderCustomizer />)
+    
+    expect(screen.getByText('総合')).toBeInTheDocument()
+    expect(screen.getByText('ゲーム')).toBeInTheDocument()
+    expect(screen.getByText('アニメ')).toBeInTheDocument()
+    expect(screen.getByText('ボカロ')).toBeInTheDocument()
+  })
+
+  it('applies different styles to hidden genres', () => {
+    render(<GenreOrderCustomizer />)
+    
+    const animeItem = screen.getByText('アニメ').closest('div[draggable]')
+    // CSS modulesはクラス名を変換するため、クラス名の部分一致で確認
+    expect(animeItem?.className).toMatch(/hidden/)
+    
+    const gameItem = screen.getByText('ゲーム').closest('div[draggable]')
+    expect(gameItem?.className).not.toMatch(/hidden/)
+  })
+
+  it('renders visibility toggle buttons', () => {
+    render(<GenreOrderCustomizer />)
+    
+    const visibilityButtons = screen.getAllByRole('button', { name: /表示する|非表示にする/ })
+    expect(visibilityButtons.length).toBe(4)
+  })
+
+  it('renders the default reset button', () => {
+    render(<GenreOrderCustomizer />)
+    
+    expect(screen.getByText('デフォルトに戻す')).toBeInTheDocument()
+  })
+
+  it('does not show apply/cancel buttons when there are no changes', () => {
+    render(<GenreOrderCustomizer />)
+    
+    expect(screen.queryByText('適用')).not.toBeInTheDocument()
+    expect(screen.queryByText('キャンセル')).not.toBeInTheDocument()
+  })
+
+  it('calls onChangesUpdate when mounted', () => {
+    const onChangesUpdate = vi.fn()
+    render(<GenreOrderCustomizer onChangesUpdate={onChangesUpdate} />)
+    
+    expect(onChangesUpdate).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('GenreOrderCustomizer v2 - Drag and Drop', () => {
+  it('sets draggable attribute on all items', () => {
+    render(<GenreOrderCustomizer />)
+    
+    const items = screen.getAllByText(/総合|ゲーム|アニメ|ボカロ/)
+      .map(el => el.closest('div[draggable]'))
+    
+    items.forEach(item => {
+      expect(item).toHaveAttribute('draggable', 'true')
+    })
+  })
+
+  it('has data-genre attribute on draggable items', () => {
+    render(<GenreOrderCustomizer />)
+    
+    const gameItem = screen.getByText('ゲーム').closest('div[draggable]')
+    expect(gameItem).toHaveAttribute('data-genre', 'game')
+  })
+})

--- a/__tests__/unit/use-genre-order-v2.test.ts
+++ b/__tests__/unit/use-genre-order-v2.test.ts
@@ -65,15 +65,24 @@ describe('useGenreOrderV2', () => {
     expect(result.current.hiddenGenres).toEqual(['all'])
   })
 
-  it('swaps items correctly', () => {
+  it('moves items correctly with insert behavior', () => {
     const { result } = renderHook(() => useGenreOrderV2())
     
+    // Initial order: [all, game, anime, ...]
+    const initialOrder = result.current.items.map(item => item.id)
+    expect(initialOrder[0]).toBe('all')
+    expect(initialOrder[1]).toBe('game')
+    expect(initialOrder[2]).toBe('anime')
+    
+    // Move 'anime' (index 2) to position of 'all' (index 0)
     act(() => {
-      result.current.swapItems('all', 'game')
+      result.current.moveItem('anime', 'all')
     })
     
-    expect(result.current.items[0].id).toBe('game')
+    // New order should be: [anime, all, game, ...]
+    expect(result.current.items[0].id).toBe('anime')
     expect(result.current.items[1].id).toBe('all')
+    expect(result.current.items[2].id).toBe('game')
     expect(result.current.hasChanges).toBe(true)
   })
 
@@ -123,7 +132,7 @@ describe('useGenreOrderV2', () => {
     const { result } = renderHook(() => useGenreOrderV2())
     
     act(() => {
-      result.current.swapItems('all', 'game')
+      result.current.moveItem('game', 'all')
     })
     
     expect(result.current.hasChanges).toBe(true)
@@ -135,26 +144,62 @@ describe('useGenreOrderV2', () => {
     const saved = JSON.parse(localStorageMock.getItem('nicoRankingGenreOrder') || '[]')
     expect(saved[0].id).toBe('game')
     expect(saved[1].id).toBe('all')
+    expect(saved[2].id).toBe('anime')
     expect(reloadMock).toHaveBeenCalled()
   })
 
   it('cancels changes correctly', () => {
     const { result } = renderHook(() => useGenreOrderV2())
     
-    const initialOrder = result.current.items[0].id
+    const initialOrder = result.current.items.map(item => item.id)
     
     act(() => {
-      result.current.swapItems('all', 'game')
+      result.current.moveItem('game', 'all')
     })
     
-    expect(result.current.items[0].id).not.toBe(initialOrder)
+    // Verify order changed
+    expect(result.current.items[0].id).toBe('game')
+    expect(result.current.items[1].id).toBe('all')
     expect(result.current.hasChanges).toBe(true)
     
     act(() => {
       result.current.cancelChanges()
     })
     
-    expect(result.current.items[0].id).toBe(initialOrder)
+    // Verify order restored
+    expect(result.current.items[0].id).toBe(initialOrder[0])
+    expect(result.current.items[1].id).toBe(initialOrder[1])
+    expect(result.current.items[2].id).toBe(initialOrder[2])
     expect(result.current.hasChanges).toBe(false)
+  })
+
+  it('handles complex insert movements correctly', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    // Initial: [all, game, anime, vocaloid, voicesynthesis, ...]
+    
+    // Move 'vocaloid' (index 3) to 'game' (index 1)
+    act(() => {
+      result.current.moveItem('vocaloid', 'game')
+    })
+    
+    // Expected: [all, vocaloid, game, anime, voicesynthesis, ...]
+    expect(result.current.items[0].id).toBe('all')
+    expect(result.current.items[1].id).toBe('vocaloid')
+    expect(result.current.items[2].id).toBe('game')
+    expect(result.current.items[3].id).toBe('anime')
+    expect(result.current.items[4].id).toBe('voicesynthesis')
+    
+    // Move 'all' (index 0) to 'anime' (index 3)
+    act(() => {
+      result.current.moveItem('all', 'anime')
+    })
+    
+    // Expected: [vocaloid, game, anime, all, voicesynthesis, ...]
+    expect(result.current.items[0].id).toBe('vocaloid')
+    expect(result.current.items[1].id).toBe('game')
+    expect(result.current.items[2].id).toBe('anime')
+    expect(result.current.items[3].id).toBe('all')
+    expect(result.current.items[4].id).toBe('voicesynthesis')
   })
 })

--- a/__tests__/unit/use-genre-order-v2.test.ts
+++ b/__tests__/unit/use-genre-order-v2.test.ts
@@ -1,0 +1,160 @@
+import { renderHook, act } from '@testing-library/react'
+import { useGenreOrderV2 } from '@/hooks/use-genre-order-v2'
+import { vi } from 'vitest'
+import type { RankingGenre } from '@/types/ranking-config'
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    }
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock
+})
+
+// Mock window.location.reload
+const reloadMock = vi.fn()
+Object.defineProperty(window, 'location', {
+  value: { reload: reloadMock },
+  writable: true
+})
+
+describe('useGenreOrderV2', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    reloadMock.mockClear()
+  })
+
+  it('returns default state when no saved data exists', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    expect(result.current.items).toHaveLength(23) // All genres
+    expect(result.current.items[0]).toEqual({
+      id: 'all',
+      isVisible: true,
+      order: 0
+    })
+    expect(result.current.visibleGenres).toHaveLength(23)
+    expect(result.current.hiddenGenres).toHaveLength(0)
+    expect(result.current.hasChanges).toBe(false)
+  })
+
+  it('loads saved state from localStorage', () => {
+    const savedData = [
+      { id: 'game' as RankingGenre, isVisible: true, order: 0 },
+      { id: 'all' as RankingGenre, isVisible: false, order: 1 },
+    ]
+    localStorageMock.setItem('nicoRankingGenreOrder', JSON.stringify(savedData))
+    
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    expect(result.current.items).toEqual(savedData)
+    expect(result.current.visibleGenres).toEqual(['game'])
+    expect(result.current.hiddenGenres).toEqual(['all'])
+  })
+
+  it('swaps items correctly', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    act(() => {
+      result.current.swapItems('all', 'game')
+    })
+    
+    expect(result.current.items[0].id).toBe('game')
+    expect(result.current.items[1].id).toBe('all')
+    expect(result.current.hasChanges).toBe(true)
+  })
+
+  it('toggles visibility correctly', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    const initialVisibleCount = result.current.visibleGenres.length
+    
+    act(() => {
+      result.current.toggleVisibility('all')
+    })
+    
+    expect(result.current.visibleGenres).not.toContain('all')
+    expect(result.current.hiddenGenres).toContain('all')
+    expect(result.current.visibleGenres.length).toBe(initialVisibleCount - 1)
+    expect(result.current.hasChanges).toBe(true)
+  })
+
+  it('resets to default correctly', () => {
+    // Set up saved state that's different from default
+    const customSavedData = [
+      { id: 'game' as RankingGenre, isVisible: true, order: 0 },
+      { id: 'all' as RankingGenre, isVisible: false, order: 1 },
+      { id: 'anime' as RankingGenre, isVisible: true, order: 2 },
+    ]
+    localStorageMock.setItem('nicoRankingGenreOrder', JSON.stringify(customSavedData))
+    
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    // Verify custom state is loaded
+    expect(result.current.items[0].id).toBe('game')
+    expect(result.current.hasChanges).toBe(false)
+    
+    // Reset to default
+    act(() => {
+      result.current.resetToDefault()
+    })
+    
+    // Check default state is restored
+    expect(result.current.items[0].id).toBe('all')
+    expect(result.current.items[0].isVisible).toBe(true)
+    expect(result.current.visibleGenres.length).toBe(23)
+    expect(result.current.hasChanges).toBe(true) // Has changes because it's different from saved state
+  })
+
+  it('applies changes and saves to localStorage', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    act(() => {
+      result.current.swapItems('all', 'game')
+    })
+    
+    expect(result.current.hasChanges).toBe(true)
+    
+    act(() => {
+      result.current.applyChanges()
+    })
+    
+    const saved = JSON.parse(localStorageMock.getItem('nicoRankingGenreOrder') || '[]')
+    expect(saved[0].id).toBe('game')
+    expect(saved[1].id).toBe('all')
+    expect(reloadMock).toHaveBeenCalled()
+  })
+
+  it('cancels changes correctly', () => {
+    const { result } = renderHook(() => useGenreOrderV2())
+    
+    const initialOrder = result.current.items[0].id
+    
+    act(() => {
+      result.current.swapItems('all', 'game')
+    })
+    
+    expect(result.current.items[0].id).not.toBe(initialOrder)
+    expect(result.current.hasChanges).toBe(true)
+    
+    act(() => {
+      result.current.cancelChanges()
+    })
+    
+    expect(result.current.items[0].id).toBe(initialOrder)
+    expect(result.current.hasChanges).toBe(false)
+  })
+})

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { RankingSelector } from '@/components/ranking-selector'
 import RankingItemResponsive from '@/components/ranking-item-responsive'
+import { VideoContextMenu } from '@/components/video-context-menu'
 import { useUserPreferences } from '@/hooks/use-user-preferences'
 import { generateNGListHash } from '@/lib/ng-list-hash'
 import { filterWithNGList } from '@/lib/filter-with-ng-list'
@@ -643,11 +644,14 @@ export default function ClientPage({
           {/* ランキングリスト */}
           <ul key={`${ngListVersion}-${config.period}`} style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {finalDisplayItems.map((item) => (
-              <RankingItemResponsive 
-                key={item.id} 
-                item={item}
-                disabled={isNavigating}
-              />
+              <li key={item.id} style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                <VideoContextMenu video={item}>
+                  <RankingItemResponsive 
+                    item={item}
+                    disabled={isNavigating}
+                  />
+                </VideoContextMenu>
+              </li>
             ))}
           </ul>
           

--- a/components/genre-order-backup.module.css
+++ b/components/genre-order-backup.module.css
@@ -181,31 +181,6 @@
   border: 1px solid rgba(239, 68, 68, 0.3);
 }
 
-/* 使い方説明 */
-.helpText {
-  margin-top: 1rem;
-  padding: 1rem;
-  background: var(--info-bg, #e8f4fd);
-  border-radius: 6px;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.helpText strong {
-  display: block;
-  margin-bottom: 0.5rem;
-}
-
-.helpText ul {
-  margin: 0.5rem 0 0 1.5rem;
-  padding: 0;
-}
-
-.helpText li {
-  margin-bottom: 0.25rem;
-}
-
 @media (max-width: 768px) {
   .backupDialog {
     padding: 1.5rem;

--- a/components/genre-order-backup.module.css
+++ b/components/genre-order-backup.module.css
@@ -1,0 +1,234 @@
+/* 基本的にng-backup.module.cssと同じスタイルを使用 */
+.genreOrderBackup {
+  margin: 1rem 0;
+}
+
+.backupActions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.backupButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.backupButton:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--primary-color);
+}
+
+.backupButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.buttonIcon {
+  width: 20px;
+  height: 20px;
+}
+
+.fileInput {
+  display: none;
+}
+
+.backupDialogOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.backupDialog {
+  background: var(--surface-color);
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: var(--shadow-xl);
+  animation: modalSlideIn 0.2s ease-out;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.backupDialog h3 {
+  margin: 0 0 1rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.backupDialog p {
+  margin: 0.5rem 0;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.dialogNote {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+/* インポート確認 */
+.importInfo {
+  margin: 1rem 0;
+  padding: 1rem;
+  background: var(--info-bg, #e8f4fd);
+  border: 1px solid var(--info-border, #b3d9f2);
+  border-radius: 8px;
+}
+
+.warningInfo {
+  margin: 1rem 0;
+  padding: 1rem;
+  background: rgba(255, 193, 7, 0.1);
+  border: 1px solid rgba(255, 193, 7, 0.3);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: #d97706;
+}
+
+.dialogActions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+.dialogButton {
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cancelButton {
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.cancelButton:hover {
+  background: var(--surface-hover);
+}
+
+.confirmButton {
+  background: var(--primary-color);
+  color: white;
+}
+
+.confirmButton:hover:not(:disabled) {
+  background: var(--primary-color-hover);
+  transform: translateY(-1px);
+}
+
+.confirmButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* インポート結果メッセージ */
+.importResult {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.importResult.success {
+  background: rgba(34, 197, 94, 0.1);
+  color: rgb(34, 197, 94);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.importResult.error {
+  background: rgba(239, 68, 68, 0.1);
+  color: rgb(239, 68, 68);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* 使い方説明 */
+.helpText {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--info-bg, #e8f4fd);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.helpText strong {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.helpText ul {
+  margin: 0.5rem 0 0 1.5rem;
+  padding: 0;
+}
+
+.helpText li {
+  margin-bottom: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .backupDialog {
+    padding: 1.5rem;
+    margin: 1rem;
+  }
+
+  .backupActions {
+    justify-content: center;
+  }
+
+  .backupButton {
+    flex: 1;
+    justify-content: center;
+    min-width: 140px;
+  }
+
+  .dialogActions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .dialogButton {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/components/genre-order-backup.tsx
+++ b/components/genre-order-backup.tsx
@@ -3,14 +3,26 @@
 import { useState } from 'react'
 import { useGenreOrderV2 } from '@/hooks/use-genre-order-v2'
 import type { GenreItem } from '@/types/genre-order'
+import styles from './genre-order-backup.module.css'
+
+interface BackupData {
+  version: number
+  exportDate: string
+  genreOrder: GenreItem[]
+}
 
 export function GenreOrderBackup() {
   const { items } = useGenreOrderV2()
+  const [isExporting, setIsExporting] = useState(false)
+  const [isImporting, setIsImporting] = useState(false)
+  const [importConfirmOpen, setImportConfirmOpen] = useState(false)
   const [importMessage, setImportMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
+  const [pendingImportData, setPendingImportData] = useState<BackupData | null>(null)
 
-  const handleExport = () => {
+  const handleExport = async () => {
+    setIsExporting(true)
     try {
-      const data = {
+      const data: BackupData = {
         version: 1,
         exportDate: new Date().toISOString(),
         genreOrder: items
@@ -28,18 +40,23 @@ export function GenreOrderBackup() {
     } catch (error) {
       console.error('Failed to export genre order:', error)
       alert('ジャンル並び替えデータのエクスポートに失敗しました')
+    } finally {
+      setIsExporting(false)
     }
   }
 
-  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     if (!file) return
+
+    setIsImporting(true)
+    setImportMessage(null)
 
     const reader = new FileReader()
     reader.onload = (e) => {
       try {
         const content = e.target?.result as string
-        const data = JSON.parse(content)
+        const data = JSON.parse(content) as BackupData
         
         // バリデーション
         if (!data.version || !data.genreOrder || !Array.isArray(data.genreOrder)) {
@@ -53,24 +70,17 @@ export function GenreOrderBackup() {
           }
         }
 
-        // LocalStorageに保存
-        localStorage.setItem('nicoRankingGenreOrder', JSON.stringify(data.genreOrder))
-        
-        setImportMessage({ 
-          type: 'success', 
-          text: 'ジャンル並び替えデータをインポートしました。ページをリロードして反映してください。' 
-        })
-        
-        // 3秒後にリロード
-        setTimeout(() => {
-          window.location.reload()
-        }, 3000)
+        // 確認ダイアログを表示
+        setPendingImportData(data)
+        setImportConfirmOpen(true)
       } catch (error) {
         console.error('Failed to import genre order:', error)
         setImportMessage({ 
           type: 'error', 
           text: error instanceof Error ? error.message : 'インポートに失敗しました' 
         })
+      } finally {
+        setIsImporting(false)
       }
     }
     
@@ -80,83 +90,131 @@ export function GenreOrderBackup() {
     event.target.value = ''
   }
 
+  const confirmImport = async () => {
+    if (!pendingImportData) return
+
+    setIsImporting(true)
+    try {
+      // LocalStorageに保存
+      localStorage.setItem('nicoRankingGenreOrder', JSON.stringify(pendingImportData.genreOrder))
+      
+      setImportMessage({ 
+        type: 'success', 
+        text: 'ジャンル並び替えデータをインポートしました。ページをリロードして反映してください。' 
+      })
+      setImportConfirmOpen(false)
+      setPendingImportData(null)
+      
+      // 3秒後にリロード
+      setTimeout(() => {
+        window.location.reload()
+      }, 3000)
+    } catch (error) {
+      console.error('Failed to apply import:', error)
+      setImportMessage({ 
+        type: 'error', 
+        text: 'インポート処理に失敗しました' 
+      })
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
   return (
-    <div>
-      <div style={{ 
-        display: 'flex', 
-        gap: '1rem', 
-        marginBottom: '1rem',
-        flexWrap: 'wrap'
-      }}>
+    <div className={styles.genreOrderBackup}>
+      <div className={styles.backupActions}>
+        {/* エクスポートボタン */}
         <button
           onClick={handleExport}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: 'var(--primary-color)',
-            color: 'white',
-            border: 'none',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontWeight: '600',
-            fontSize: '0.95rem',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem'
-          }}
+          disabled={isExporting}
+          className={`${styles.backupButton} ${styles.exportButton}`}
+          data-testid="export-genre-order-button"
         >
-          📥 エクスポート
+          <svg className={styles.buttonIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8h3a2 2 0 002-2v-11a2 2 0 00-2-2h-3m-10 0H4a2 2 0 00-2 2v11a2 2 0 002 2h3" />
+          </svg>
+          エクスポート
         </button>
         
-        <label style={{
-          padding: '0.75rem 1.5rem',
-          background: 'var(--surface-secondary)',
-          border: '1px solid var(--border-color)',
-          borderRadius: '6px',
-          cursor: 'pointer',
-          fontWeight: '600',
-          fontSize: '0.95rem',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '0.5rem'
-        }}>
-          📤 インポート
+        {/* インポートボタン */}
+        <label className={`${styles.backupButton} ${styles.importButton}`} data-testid="import-genre-order-button">
           <input
             type="file"
             accept=".json"
             onChange={handleImport}
-            style={{ display: 'none' }}
+            disabled={isImporting}
+            className={styles.fileInput}
+            data-testid="import-file-input"
           />
+          <svg className={styles.buttonIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v6m0 0l-3-3m3 3l3-3m2 8h3a2 2 0 012 2v3a2 2 0 01-2-2h-3m-10 0H4a2 2 0 01-2-2v-3a2 2 0 012-2h3" />
+          </svg>
+          インポート
         </label>
       </div>
-      
+
+      {/* インポート確認ダイアログ */}
+      {importConfirmOpen && pendingImportData && (
+        <div className={styles.backupDialogOverlay} onClick={() => setImportConfirmOpen(false)}>
+          <div 
+            className={styles.backupDialog} 
+            onClick={(e) => e.stopPropagation()}
+            data-testid="import-confirm-dialog"
+          >
+            <h3>ジャンル並び替えデータをインポート</h3>
+            <p>
+              選択されたバックアップファイルからジャンル並び替え設定を復元します。
+            </p>
+            
+            <div className={styles.importInfo}>
+              <div>バックアップ日時: {new Date(pendingImportData.exportDate).toLocaleString('ja-JP')}</div>
+              <div>ジャンル数: {pendingImportData.genreOrder.length}項目</div>
+            </div>
+
+            <div className={styles.warningInfo}>
+              ⚠️ 現在のジャンル並び替え設定は完全に上書きされます。
+            </div>
+
+            <p className={styles.dialogNote}>
+              この操作は取り消すことができません。必要に応じて現在の設定をエクスポートしてバックアップを取ってください。
+            </p>
+
+            <div className={styles.dialogActions}>
+              <button 
+                onClick={() => {
+                  setImportConfirmOpen(false)
+                  setPendingImportData(null)
+                }}
+                className={`${styles.dialogButton} ${styles.cancelButton}`}
+              >
+                キャンセル
+              </button>
+              <button 
+                onClick={confirmImport}
+                disabled={isImporting}
+                className={`${styles.dialogButton} ${styles.confirmButton}`}
+              >
+                {isImporting ? 'インポート中...' : 'インポート実行'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* インポート結果メッセージ */}
       {importMessage && (
-        <div style={{
-          padding: '1rem',
-          borderRadius: '6px',
-          background: importMessage.type === 'success' 
-            ? 'var(--success-bg, #e6f4ea)' 
-            : 'var(--error-bg, #fef1f1)',
-          color: importMessage.type === 'success'
-            ? 'var(--success-color, #1e7e34)'
-            : 'var(--error-color, #d73502)',
-          marginTop: '1rem',
-          lineHeight: 1.5
-        }}>
+        <div 
+          className={`${styles.importResult} ${importMessage.type === 'success' ? styles.success : styles.error}`}
+          data-testid={importMessage.type === 'success' ? 'import-success-message' : 'import-error-message'}
+        >
           {importMessage.text}
         </div>
       )}
       
-      <div style={{
-        marginTop: '1rem',
-        padding: '1rem',
-        background: 'var(--info-bg, #e8f4fd)',
-        borderRadius: '6px',
-        fontSize: '0.85rem',
-        color: 'var(--text-secondary)',
-        lineHeight: 1.6
-      }}>
+      {/* 使い方説明 */}
+      <div className={styles.helpText}>
         <strong>📌 使い方:</strong>
-        <ul style={{ margin: '0.5rem 0 0 1.5rem', padding: 0 }}>
+        <ul>
           <li>エクスポート: 現在のジャンル並び替え設定をファイルに保存します</li>
           <li>インポート: 保存したファイルから設定を復元します</li>
           <li>インポート後は自動的にページがリロードされます</li>

--- a/components/genre-order-backup.tsx
+++ b/components/genre-order-backup.tsx
@@ -212,16 +212,6 @@ export function GenreOrderBackup() {
           {importMessage.text}
         </div>
       )}
-      
-      {/* 使い方説明 */}
-      <div className={styles.helpText}>
-        <strong>📌 使い方:</strong>
-        <ul>
-          <li>エクスポート: 現在のジャンル並び替え設定をファイルに保存します</li>
-          <li>インポート: 保存したファイルから設定を復元します</li>
-          <li>インポート後はページのリロードが必要です</li>
-        </ul>
-      </div>
     </div>
   )
 }

--- a/components/genre-order-backup.tsx
+++ b/components/genre-order-backup.tsx
@@ -100,15 +100,17 @@ export function GenreOrderBackup() {
       
       setImportMessage({ 
         type: 'success', 
-        text: 'ジャンル並び替えデータをインポートしました。ページをリロードして反映してください。' 
+        text: 'ジャンル並び替えデータをインポートしました。' 
       })
       setImportConfirmOpen(false)
       setPendingImportData(null)
       
-      // 3秒後にリロード
+      // リロード確認
       setTimeout(() => {
-        window.location.reload()
-      }, 3000)
+        if (confirm('インポートが完了しました。ページをリロードして変更を反映しますか？')) {
+          window.location.reload()
+        }
+      }, 1500)
     } catch (error) {
       console.error('Failed to apply import:', error)
       setImportMessage({ 
@@ -217,7 +219,7 @@ export function GenreOrderBackup() {
         <ul>
           <li>エクスポート: 現在のジャンル並び替え設定をファイルに保存します</li>
           <li>インポート: 保存したファイルから設定を復元します</li>
-          <li>インポート後は自動的にページがリロードされます</li>
+          <li>インポート後はページのリロードが必要です</li>
         </ul>
       </div>
     </div>

--- a/components/genre-order-backup.tsx
+++ b/components/genre-order-backup.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState } from 'react'
+import { useGenreOrderV2 } from '@/hooks/use-genre-order-v2'
+import type { GenreItem } from '@/types/genre-order'
+
+export function GenreOrderBackup() {
+  const { items } = useGenreOrderV2()
+  const [importMessage, setImportMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
+
+  const handleExport = () => {
+    try {
+      const data = {
+        version: 1,
+        exportDate: new Date().toISOString(),
+        genreOrder: items
+      }
+      
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `genre-order-backup-${new Date().toISOString().split('T')[0]}.json`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      console.error('Failed to export genre order:', error)
+      alert('ジャンル並び替えデータのエクスポートに失敗しました')
+    }
+  }
+
+  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string
+        const data = JSON.parse(content)
+        
+        // バリデーション
+        if (!data.version || !data.genreOrder || !Array.isArray(data.genreOrder)) {
+          throw new Error('無効なバックアップファイル形式です')
+        }
+
+        // 各アイテムのバリデーション
+        for (const item of data.genreOrder) {
+          if (!item.id || typeof item.isVisible !== 'boolean' || typeof item.order !== 'number') {
+            throw new Error('無効なジャンルデータが含まれています')
+          }
+        }
+
+        // LocalStorageに保存
+        localStorage.setItem('nicoRankingGenreOrder', JSON.stringify(data.genreOrder))
+        
+        setImportMessage({ 
+          type: 'success', 
+          text: 'ジャンル並び替えデータをインポートしました。ページをリロードして反映してください。' 
+        })
+        
+        // 3秒後にリロード
+        setTimeout(() => {
+          window.location.reload()
+        }, 3000)
+      } catch (error) {
+        console.error('Failed to import genre order:', error)
+        setImportMessage({ 
+          type: 'error', 
+          text: error instanceof Error ? error.message : 'インポートに失敗しました' 
+        })
+      }
+    }
+    
+    reader.readAsText(file)
+    
+    // ファイル選択をリセット
+    event.target.value = ''
+  }
+
+  return (
+    <div>
+      <div style={{ 
+        display: 'flex', 
+        gap: '1rem', 
+        marginBottom: '1rem',
+        flexWrap: 'wrap'
+      }}>
+        <button
+          onClick={handleExport}
+          style={{
+            padding: '0.75rem 1.5rem',
+            background: 'var(--primary-color)',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer',
+            fontWeight: '600',
+            fontSize: '0.95rem',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
+          }}
+        >
+          📥 エクスポート
+        </button>
+        
+        <label style={{
+          padding: '0.75rem 1.5rem',
+          background: 'var(--surface-secondary)',
+          border: '1px solid var(--border-color)',
+          borderRadius: '6px',
+          cursor: 'pointer',
+          fontWeight: '600',
+          fontSize: '0.95rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem'
+        }}>
+          📤 インポート
+          <input
+            type="file"
+            accept=".json"
+            onChange={handleImport}
+            style={{ display: 'none' }}
+          />
+        </label>
+      </div>
+      
+      {importMessage && (
+        <div style={{
+          padding: '1rem',
+          borderRadius: '6px',
+          background: importMessage.type === 'success' 
+            ? 'var(--success-bg, #e6f4ea)' 
+            : 'var(--error-bg, #fef1f1)',
+          color: importMessage.type === 'success'
+            ? 'var(--success-color, #1e7e34)'
+            : 'var(--error-color, #d73502)',
+          marginTop: '1rem',
+          lineHeight: 1.5
+        }}>
+          {importMessage.text}
+        </div>
+      )}
+      
+      <div style={{
+        marginTop: '1rem',
+        padding: '1rem',
+        background: 'var(--info-bg, #e8f4fd)',
+        borderRadius: '6px',
+        fontSize: '0.85rem',
+        color: 'var(--text-secondary)',
+        lineHeight: 1.6
+      }}>
+        <strong>📌 使い方:</strong>
+        <ul style={{ margin: '0.5rem 0 0 1.5rem', padding: 0 }}>
+          <li>エクスポート: 現在のジャンル並び替え設定をファイルに保存します</li>
+          <li>インポート: 保存したファイルから設定を復元します</li>
+          <li>インポート後は自動的にページがリロードされます</li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/components/genre-order/genre-item.tsx
+++ b/components/genre-order/genre-item.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import React from 'react'
+import { RankingGenre } from '@/types/ranking-config'
+import { GENRE_LABELS } from '@/types/ranking-config'
+import styles from './genre-order.module.css'
+
+interface GenreItemProps {
+  genre: RankingGenre
+  isVisible: boolean
+  onToggleVisibility: () => void
+  isDragging?: boolean
+  onDragStart: (e: React.DragEvent<HTMLDivElement>) => void
+  onDragEnd: (e: React.DragEvent<HTMLDivElement>) => void
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void
+}
+
+export const GenreItem = React.memo(function GenreItem({
+  genre,
+  isVisible,
+  onToggleVisibility,
+  isDragging = false,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop
+}: GenreItemProps) {
+  return (
+    <div 
+      className={`${styles.genreItem} ${!isVisible ? styles.hidden : ''} ${isDragging ? styles.dragging : ''}`}
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      data-genre={genre}
+    >
+      <div className={styles.dragHandle}>
+        <span className={styles.dragIcon}>☰</span>
+      </div>
+      
+      <div className={styles.genreLabel}>
+        {GENRE_LABELS[genre]}
+      </div>
+      
+      <button
+        className={styles.visibilityToggle}
+        onClick={onToggleVisibility}
+        title={isVisible ? '非表示にする' : '表示する'}
+        aria-label={isVisible ? `${GENRE_LABELS[genre]}を非表示にする` : `${GENRE_LABELS[genre]}を表示する`}
+      >
+        {isVisible ? '👁️' : '👁️‍🗨️'}
+      </button>
+    </div>
+  )
+})

--- a/components/genre-order/genre-order.module.css
+++ b/components/genre-order/genre-order.module.css
@@ -159,3 +159,39 @@
   border-color: var(--primary-color);
 }
 
+/* Scroll Indicators */
+.scrollIndicatorTop,
+.scrollIndicatorBottom {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(85, 103, 216, 0.9);
+  color: white;
+  padding: 8px 24px;
+  border-radius: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  pointer-events: none;
+  z-index: 1000;
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.scrollIndicatorTop {
+  top: 20px;
+}
+
+.scrollIndicatorBottom {
+  bottom: 20px;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.9;
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(-50%) scale(1.05);
+  }
+}
+

--- a/components/genre-order/genre-order.module.css
+++ b/components/genre-order/genre-order.module.css
@@ -1,0 +1,228 @@
+/* Genre Order Customizer Styles */
+
+.container {
+  padding: 16px;
+}
+
+.description {
+  margin-bottom: 16px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.genreList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+/* Genre Item */
+.genreItem {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  transition: all 0.2s ease-in-out;
+  cursor: move;
+  user-select: none;
+}
+
+.genreItem:hover {
+  background: var(--surface-active);
+  border-color: var(--border-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.genreItem.hidden {
+  opacity: 0.6;
+  background: var(--surface-secondary);
+}
+
+.genreItem.dragging {
+  opacity: 0.5;
+  transform: scale(1.02);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Drag Handle */
+.dragHandle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+  cursor: grab;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.dragIcon {
+  font-size: 16px;
+  color: var(--text-secondary);
+}
+
+/* Genre Label */
+.genreLabel {
+  flex: 1;
+  font-weight: 500;
+  font-size: 14px;
+}
+
+/* Visibility Toggle */
+.visibilityToggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  padding: 4px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.visibilityToggle:hover {
+  background-color: var(--surface-hover);
+}
+
+.visibilityToggle:active {
+  transform: scale(0.95);
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-color);
+}
+
+.resetButton {
+  padding: 8px 16px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.resetButton:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
+.resetButton:active {
+  transform: scale(0.98);
+}
+
+.buttonGroup {
+  display: flex;
+  gap: 8px;
+}
+
+.cancelButton {
+  padding: 8px 16px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.cancelButton:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-hover);
+}
+
+.applyButton {
+  padding: 8px 16px;
+  background: var(--primary-color);
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: white;
+  transition: all 0.2s ease;
+}
+
+.applyButton:hover {
+  background: var(--primary-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(var(--primary-rgb), 0.3);
+}
+
+.applyButton:active {
+  transform: scale(0.98);
+}
+
+.applyButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Help Text */
+.helpText {
+  margin-top: 16px;
+  padding: 12px;
+  background: var(--info-bg);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.helpText ul {
+  margin: 8px 0 0 20px;
+  padding: 0;
+}
+
+.helpText li {
+  margin-bottom: 4px;
+}
+
+/* Drag Over Effects */
+.dragOver {
+  background: var(--surface-active);
+  border-color: var(--primary-color);
+}
+
+/* Scrollbar Styles */
+.genreList::-webkit-scrollbar {
+  width: 8px;
+}
+
+.genreList::-webkit-scrollbar-track {
+  background: var(--surface-secondary);
+  border-radius: 4px;
+}
+
+.genreList::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+.genreList::-webkit-scrollbar-thumb:hover {
+  background: var(--border-hover);
+}

--- a/components/genre-order/genre-order.module.css
+++ b/components/genre-order/genre-order.module.css
@@ -16,8 +16,6 @@
   flex-direction: column;
   gap: 8px;
   margin-bottom: 24px;
-  max-height: 400px;
-  overflow-y: auto;
   padding: 4px;
 }
 
@@ -134,53 +132,6 @@
   transform: scale(0.98);
 }
 
-.buttonGroup {
-  display: flex;
-  gap: 8px;
-}
-
-.cancelButton {
-  padding: 8px 16px;
-  background: var(--surface-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  font-size: 14px;
-  cursor: pointer;
-  color: var(--text-secondary);
-  transition: all 0.2s ease;
-}
-
-.cancelButton:hover {
-  background: var(--surface-hover);
-  border-color: var(--border-hover);
-}
-
-.applyButton {
-  padding: 8px 16px;
-  background: var(--primary-color);
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  color: white;
-  transition: all 0.2s ease;
-}
-
-.applyButton:hover {
-  background: var(--primary-hover);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(var(--primary-rgb), 0.3);
-}
-
-.applyButton:active {
-  transform: scale(0.98);
-}
-
-.applyButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 /* Help Text */
 .helpText {
@@ -208,21 +159,3 @@
   border-color: var(--primary-color);
 }
 
-/* Scrollbar Styles */
-.genreList::-webkit-scrollbar {
-  width: 8px;
-}
-
-.genreList::-webkit-scrollbar-track {
-  background: var(--surface-secondary);
-  border-radius: 4px;
-}
-
-.genreList::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 4px;
-}
-
-.genreList::-webkit-scrollbar-thumb:hover {
-  background: var(--border-hover);
-}

--- a/components/genre-order/index.tsx
+++ b/components/genre-order/index.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import React, { forwardRef, useImperativeHandle, useState, useCallback } from 'react'
+import { useGenreOrderV2 } from '@/hooks/use-genre-order-v2'
+import { GenreItem } from './genre-item'
+import { RankingGenre } from '@/types/ranking-config'
+import styles from './genre-order.module.css'
+
+interface GenreOrderCustomizerProps {
+  onChangesUpdate?: (hasChanges: boolean) => void
+}
+
+export interface GenreOrderCustomizerRef {
+  applyChanges: () => void
+  cancelChanges: () => void
+}
+
+export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrderCustomizerProps>(
+  function GenreOrderCustomizer({ onChangesUpdate }, ref) {
+    const {
+      items,
+      hasChanges,
+      swapItems,
+      toggleVisibility,
+      resetToDefault,
+      applyChanges,
+      cancelChanges
+    } = useGenreOrderV2()
+
+    // ドラッグ中のアイテム
+    const [draggedGenre, setDraggedGenre] = useState<RankingGenre | null>(null)
+
+    // 変更状態を親に通知
+    React.useEffect(() => {
+      onChangesUpdate?.(hasChanges)
+    }, [hasChanges, onChangesUpdate])
+
+    // ドラッグ&ドロップハンドラー
+    const handleDragStart = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+      const genre = e.currentTarget.getAttribute('data-genre') as RankingGenre
+      setDraggedGenre(genre)
+      e.dataTransfer.effectAllowed = 'move'
+    }, [])
+
+    const handleDragEnd = useCallback(() => {
+      setDraggedGenre(null)
+    }, [])
+
+    const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+    }, [])
+
+    const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      const dropGenre = e.currentTarget.getAttribute('data-genre') as RankingGenre
+      
+      if (draggedGenre && draggedGenre !== dropGenre) {
+        swapItems(draggedGenre, dropGenre)
+      }
+      
+      setDraggedGenre(null)
+    }, [draggedGenre, swapItems])
+
+    // 外部から呼び出し可能なメソッドを公開
+    useImperativeHandle(ref, () => ({
+      applyChanges,
+      cancelChanges
+    }))
+
+    return (
+      <div className={styles.container}>
+        <p className={styles.description}>
+          ドラッグ&ドロップでジャンルの順序を変更したり、表示/非表示を切り替えることができます。
+        </p>
+
+        <div className={styles.genreList}>
+          {items.map((item) => (
+            <GenreItem
+              key={item.id}
+              genre={item.id}
+              isVisible={item.isVisible}
+              isDragging={draggedGenre === item.id}
+              onToggleVisibility={() => toggleVisibility(item.id)}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+            />
+          ))}
+        </div>
+
+        <div className={styles.helpText}>
+          <strong>💡 使い方:</strong>
+          <ul>
+            <li>☰ ドラッグハンドルを掴んで順序を変更</li>
+            <li>👁️ アイコンで表示/非表示を切り替え</li>
+            <li>変更は「適用」ボタンで保存されます</li>
+          </ul>
+        </div>
+
+        <div className={styles.actions}>
+          <button 
+            className={styles.resetButton}
+            onClick={resetToDefault}
+          >
+            デフォルトに戻す
+          </button>
+          
+          {hasChanges && (
+            <div className={styles.buttonGroup}>
+              <button 
+                className={styles.cancelButton}
+                onClick={cancelChanges}
+              >
+                キャンセル
+              </button>
+              <button 
+                className={styles.applyButton}
+                onClick={applyChanges}
+              >
+                適用
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+GenreOrderCustomizer.displayName = 'GenreOrderCustomizer'

--- a/components/genre-order/index.tsx
+++ b/components/genre-order/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { forwardRef, useImperativeHandle, useState, useCallback } from 'react'
+import React, { forwardRef, useImperativeHandle, useState, useCallback, useRef, useEffect } from 'react'
 import { useGenreOrderV2 } from '@/hooks/use-genre-order-v2'
 import { GenreItem } from './genre-item'
 import { RankingGenre } from '@/types/ranking-config'
@@ -29,21 +29,120 @@ export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrd
 
     // ドラッグ中のアイテム
     const [draggedGenre, setDraggedGenre] = useState<RankingGenre | null>(null)
+    
+    // 自動スクロール用の参照とstate
+    const scrollContainerRef = useRef<HTMLElement | null>(null)
+    const [isDragging, setIsDragging] = useState(false)
+    const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 })
+    const scrollIntervalRef = useRef<number | null>(null)
+    const [scrollDirection, setScrollDirection] = useState<'up' | 'down' | null>(null)
 
     // 変更状態を親に通知
     React.useEffect(() => {
       onChangesUpdate?.(hasChanges)
     }, [hasChanges, onChangesUpdate])
 
+    // スクロールコンテナを検索
+    useEffect(() => {
+      // 親要素から overflow-y が auto または scroll の要素を探す
+      const findScrollContainer = () => {
+        let element = document.querySelector('.genreOrderContainer')?.parentElement
+        while (element && element.tagName !== 'BODY') {
+          const computedStyle = getComputedStyle(element)
+          if (computedStyle.overflowY === 'auto' || 
+              computedStyle.overflowY === 'scroll') {
+            return element
+          }
+          element = element.parentElement
+        }
+        return null
+      }
+      
+      scrollContainerRef.current = findScrollContainer()
+    }, [])
+
+    // 自動スクロール処理
+    useEffect(() => {
+      if (!isDragging || !scrollContainerRef.current) return
+
+      const container = scrollContainerRef.current
+      const containerRect = container.getBoundingClientRect()
+      
+      // スクロール検知エリアのサイズ（上下100px）
+      const scrollZoneSize = 100
+      // 最大スクロール速度
+      const maxScrollSpeed = 20
+      
+      const autoScroll = () => {
+        const mouseY = dragPosition.y
+        
+        // 上部エリアでのスクロール
+        if (mouseY < containerRect.top + scrollZoneSize) {
+          const distance = containerRect.top + scrollZoneSize - mouseY
+          const speed = Math.min((distance / scrollZoneSize) * maxScrollSpeed, maxScrollSpeed)
+          container.scrollTop -= speed
+          setScrollDirection('up')
+        }
+        // 下部エリアでのスクロール
+        else if (mouseY > containerRect.bottom - scrollZoneSize) {
+          const distance = mouseY - (containerRect.bottom - scrollZoneSize)
+          const speed = Math.min((distance / scrollZoneSize) * maxScrollSpeed, maxScrollSpeed)
+          container.scrollTop += speed
+          setScrollDirection('down')
+        }
+        // スクロールエリア外
+        else {
+          setScrollDirection(null)
+        }
+      }
+
+      // requestAnimationFrameでスムーズなスクロール
+      const animate = () => {
+        autoScroll()
+        scrollIntervalRef.current = requestAnimationFrame(animate)
+      }
+      
+      scrollIntervalRef.current = requestAnimationFrame(animate)
+
+      return () => {
+        if (scrollIntervalRef.current) {
+          cancelAnimationFrame(scrollIntervalRef.current)
+        }
+      }
+    }, [isDragging, dragPosition])
+
+    // ドラッグ位置の更新
+    useEffect(() => {
+      const handleMouseMove = (e: MouseEvent) => {
+        if (isDragging) {
+          setDragPosition({ x: e.clientX, y: e.clientY })
+        }
+      }
+
+      if (isDragging) {
+        document.addEventListener('mousemove', handleMouseMove)
+        return () => {
+          document.removeEventListener('mousemove', handleMouseMove)
+        }
+      }
+    }, [isDragging])
+
     // ドラッグ&ドロップハンドラー
     const handleDragStart = useCallback((e: React.DragEvent<HTMLDivElement>) => {
       const genre = e.currentTarget.getAttribute('data-genre') as RankingGenre
       setDraggedGenre(genre)
+      setIsDragging(true)
+      setDragPosition({ x: e.clientX, y: e.clientY })
       e.dataTransfer.effectAllowed = 'move'
     }, [])
 
     const handleDragEnd = useCallback(() => {
       setDraggedGenre(null)
+      setIsDragging(false)
+      setScrollDirection(null)
+      if (scrollIntervalRef.current) {
+        cancelAnimationFrame(scrollIntervalRef.current)
+      }
     }, [])
 
     const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -74,7 +173,19 @@ export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrd
           ドラッグ&ドロップでジャンルの順序を変更したり、表示/非表示を切り替えることができます。
         </p>
 
-        <div className={styles.genreList}>
+        {/* スクロールインジケーター */}
+        {isDragging && scrollDirection === 'up' && (
+          <div className={styles.scrollIndicatorTop}>
+            <span>↑ スクロール中 ↑</span>
+          </div>
+        )}
+        {isDragging && scrollDirection === 'down' && (
+          <div className={styles.scrollIndicatorBottom}>
+            <span>↓ スクロール中 ↓</span>
+          </div>
+        )}
+
+        <div className={`${styles.genreList} genreOrderContainer`}>
           {items.map((item) => (
             <GenreItem
               key={item.id}

--- a/components/genre-order/index.tsx
+++ b/components/genre-order/index.tsx
@@ -106,23 +106,6 @@ export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrd
           >
             デフォルトに戻す
           </button>
-          
-          {hasChanges && (
-            <div className={styles.buttonGroup}>
-              <button 
-                className={styles.cancelButton}
-                onClick={cancelChanges}
-              >
-                キャンセル
-              </button>
-              <button 
-                className={styles.applyButton}
-                onClick={applyChanges}
-              >
-                適用
-              </button>
-            </div>
-          )}
         </div>
       </div>
     )

--- a/components/genre-order/index.tsx
+++ b/components/genre-order/index.tsx
@@ -20,7 +20,7 @@ export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrd
     const {
       items,
       hasChanges,
-      swapItems,
+      moveItem,
       toggleVisibility,
       resetToDefault,
       applyChanges,
@@ -56,11 +56,11 @@ export const GenreOrderCustomizer = forwardRef<GenreOrderCustomizerRef, GenreOrd
       const dropGenre = e.currentTarget.getAttribute('data-genre') as RankingGenre
       
       if (draggedGenre && draggedGenre !== dropGenre) {
-        swapItems(draggedGenre, dropGenre)
+        moveItem(draggedGenre, dropGenre)
       }
       
       setDraggedGenre(null)
-    }, [draggedGenre, swapItems])
+    }, [draggedGenre, moveItem])
 
     // 外部から呼び出し可能なメソッドを公開
     useImperativeHandle(ref, () => ({

--- a/components/ng-backup.tsx
+++ b/components/ng-backup.tsx
@@ -65,13 +65,7 @@ export function NGBackup() {
         const result = await importNGListData(data, 'merge')
         setImportResult(result)
         
-        if (result.success) {
-          setTimeout(() => {
-            if (confirm('インポートが完了しました。ページをリロードして変更を反映しますか？')) {
-              window.location.reload()
-            }
-          }, 1500)
-        }
+        // NGリストは即座に反映されるのでリロード不要
       }
     } catch (error) {
       setImportResult({
@@ -112,13 +106,7 @@ export function NGBackup() {
       setConflictDialogOpen(false)
       setConflictData(null)
       
-      if (result.success) {
-        setTimeout(() => {
-          if (confirm('インポートが完了しました。ページをリロードして変更を反映しますか？')) {
-            window.location.reload()
-          }
-        }, 1500)
-      }
+      // NGリストは即座に反映されるのでリロード不要
     } catch (error) {
       setImportResult({
         success: false,
@@ -360,9 +348,6 @@ export function NGBackup() {
                     ⚠️ 既存のNGリストが上書きされました
                   </div>
                 )}
-              </div>
-              <div className={styles.reloadPrompt}>
-                ⚠️ 変更を反映するにはページをリロードしてください
               </div>
             </div>
           ) : (

--- a/components/ranking-item-responsive.tsx
+++ b/components/ranking-item-responsive.tsx
@@ -3,7 +3,6 @@
 import { memo, useRef, useEffect, useState } from 'react'
 import { OptimizedImage } from './optimized-image'
 import { MylistButton } from './mylist-button'
-import { VideoContextMenu } from './video-context-menu'
 import { formatRegisteredDate, isWithin24Hours } from '@/lib/date-utils'
 import { formatNumberMobile, formatTimeAgo, formatTimeCompact, formatDuration } from '@/lib/format-utils'
 import { getLinkTarget, navigateToVideo } from '@/lib/pwa-utils'
@@ -17,6 +16,7 @@ interface RankingItemProps {
 // CSS-only レスポンシブ対応版ランキングアイテム
 // Media Queriesとflexbox/gridを活用してCLSを完全に回避
 // パフォーマンス最適化: Container Query → Media Query移行完了
+// HTML構造修正: VideoContextMenuは親コンポーネントで配置
 const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabled = false }: RankingItemProps) {
   const rankColors: Record<number, string> = {
     1: 'var(--rank-gold)',
@@ -76,28 +76,27 @@ const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabl
   }
 
   return (
-    <VideoContextMenu video={item}>
-      <li 
-        data-testid="ranking-item"
-        data-video-id={item.id}
-        className="ranking-item-responsive"
-        style={{
-          // Media Query最適化: containerTypeを削除（Container Query → Media Query移行完了）
-          background: 'var(--surface-color)',
-          borderRadius: '8px',
-          overflow: 'hidden',
-          boxShadow: 'var(--shadow-md)',
-          border: item.rank <= 3 ? `2px solid ${rankColors[item.rank]}` : '1px solid var(--border-color)',
-          marginBottom: '8px',
-          cursor: disabled ? 'not-allowed' : 'pointer',
-          transition: 'background-color 0.2s',
-          position: 'relative',
-          opacity: disabled ? 0.6 : 1
-        }}
-        onClick={(e) => {
-          // disabled状態では何もしない
-          if (disabled) return;
-          // 投稿者リンクやボタンなどの子要素のクリックは除外
+    <div 
+      data-testid="ranking-item"
+      data-video-id={item.id}
+      className="ranking-item-responsive"
+      style={{
+        // Media Query最適化: containerTypeを削除（Container Query → Media Query移行完了）
+        background: 'var(--surface-color)',
+        borderRadius: '8px',
+        overflow: 'hidden',
+        boxShadow: 'var(--shadow-md)',
+        border: item.rank <= 3 ? `2px solid ${rankColors[item.rank]}` : '1px solid var(--border-color)',
+        marginBottom: '8px',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        transition: 'background-color 0.2s',
+        position: 'relative',
+        opacity: disabled ? 0.6 : 1
+      }}
+      onClick={(e) => {
+        // disabled状態では何もしない
+        if (disabled) return;
+        // 投稿者リンクやボタンなどの子要素のクリックは除外
           const target = e.target as HTMLElement;
           if (target.closest('a') || target.closest('button')) return;
           handleVideoClick();
@@ -377,8 +376,7 @@ const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabl
           <MylistButton video={item} />
         </div>
       </div>
-    </li>
-    </VideoContextMenu>
+    </div>
   )
 }, (prevProps, nextProps) => {
   // メモ化の比較関数

--- a/components/ranking-selector.tsx
+++ b/components/ranking-selector.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react'
 import { GENRE_LABELS, PERIOD_LABELS } from '@/types/ranking-config'
 import type { RankingGenre, RankingPeriod, RankingConfig } from '@/types/ranking-config'
+import { useGenreOrder } from '@/hooks/use-genre-order'
 import styles from './selectors.module.css'
 
 interface RankingSelectorProps {
@@ -12,6 +13,7 @@ interface RankingSelectorProps {
 
 export function RankingSelector({ config, onConfigChange }: RankingSelectorProps) {
   const genreScrollRef = useRef<HTMLDivElement>(null)
+  const { order: visibleGenres } = useGenreOrder()
 
   const handlePeriodChange = (period: RankingPeriod) => {
     onConfigChange({ ...config, period })
@@ -82,14 +84,14 @@ export function RankingSelector({ config, onConfigChange }: RankingSelectorProps
             ref={genreScrollRef}
             className={`${styles.buttonContainer} ${styles.genreScrollContainer}`}
           >
-            {(Object.entries(GENRE_LABELS) as [RankingGenre, string][]).map(([value, label]) => (
+            {visibleGenres.map((genre) => (
               <button
-                key={value}
+                key={genre}
                 // refを削除（CSS Scroll Snapに任せる）
-                onClick={() => handleGenreChange(value)}
-                className={`${styles.button} ${styles.genreButton} ${config.genre === value ? `${styles.buttonSelected} ${styles.genreButtonSelected}` : ''}`}
+                onClick={() => handleGenreChange(genre)}
+                className={`${styles.button} ${styles.genreButton} ${config.genre === genre ? `${styles.buttonSelected} ${styles.genreButtonSelected}` : ''}`}
               >
-                {label}
+                {GENRE_LABELS[genre]}
               </button>
             ))}
           </div>

--- a/components/settings-modal.module.css
+++ b/components/settings-modal.module.css
@@ -87,6 +87,10 @@
   transition: all 0.2s;
   white-space: nowrap;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: fit-content;
 }
 
 .tab:hover {

--- a/components/settings-modal.module.css
+++ b/components/settings-modal.module.css
@@ -67,17 +67,26 @@
   display: flex;
   border-bottom: 1px solid var(--border-color);
   padding: 0 20px;
+  overflow-x: auto;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.tabs::-webkit-scrollbar {
+  display: none; /* Chrome/Safari/Opera */
 }
 
 .tab {
   background: none;
   border: none;
-  padding: 12px 24px;
+  padding: 12px 16px;
   font-size: 1rem;
   cursor: pointer;
   color: var(--text-secondary);
   border-bottom: 2px solid transparent;
   transition: all 0.2s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab:hover {
@@ -303,5 +312,17 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* 小画面でのタブ調整 */
+@media (max-width: 480px) {
+  .tabs {
+    padding: 0 10px;
+  }
+  
+  .tab {
+    padding: 12px 12px;
+    font-size: 0.9rem;
   }
 }

--- a/components/settings-modal.module.css
+++ b/components/settings-modal.module.css
@@ -79,7 +79,7 @@
 .tab {
   background: none;
   border: none;
-  padding: 16px 20px;
+  padding: 20px 24px;
   font-size: 1rem;
   cursor: pointer;
   color: var(--text-secondary);
@@ -327,7 +327,7 @@
   }
   
   .tab {
-    padding: 14px 14px;
+    padding: 16px 16px;
     font-size: 0.9rem;
   }
 }

--- a/components/settings-modal.module.css
+++ b/components/settings-modal.module.css
@@ -79,7 +79,7 @@
 .tab {
   background: none;
   border: none;
-  padding: 12px 16px;
+  padding: 16px 20px;
   font-size: 1rem;
   cursor: pointer;
   color: var(--text-secondary);
@@ -91,6 +91,7 @@
   align-items: center;
   gap: 4px;
   min-width: fit-content;
+  line-height: 1.5;
 }
 
 .tab:hover {
@@ -326,7 +327,7 @@
   }
   
   .tab {
-    padding: 12px 12px;
+    padding: 14px 14px;
     font-size: 0.9rem;
   }
 }

--- a/components/settings-modal.module.css
+++ b/components/settings-modal.module.css
@@ -110,6 +110,18 @@
   gap: 24px;
 }
 
+.genreOrderSettings {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.ngBackupSettings {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .section {
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useUserNGList, type UserNGList } from '@/hooks/use-user-ng-list'
 import { useUserPreferences, type ThemeType } from '@/hooks/use-user-preferences'
 import { NGBackup } from './ng-backup'
+import { GenreOrderCustomizer, type GenreOrderCustomizerRef } from './genre-order'
 import styles from './settings-modal.module.css'
 
 interface SettingsModalProps {
@@ -13,7 +14,7 @@ interface SettingsModalProps {
 }
 
 export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) {
-  const [activeTab, setActiveTab] = useState<'display' | 'nglist' | 'ng-backup'>('nglist')
+  const [activeTab, setActiveTab] = useState<'display' | 'nglist' | 'genre-order' | 'ng-backup'>('nglist')
   const [inputVideoId, setInputVideoId] = useState('')
   const [inputVideoTitle, setInputVideoTitle] = useState('')
   const [videoTitleType, setVideoTitleType] = useState<'exact' | 'partial'>('partial')
@@ -26,12 +27,17 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
   // 一時的なNGリストの状態
   const [tempNGList, setTempNGList] = useState<UserNGList>(ngList)
   const [hasChanges, setHasChanges] = useState(false)
+  const [hasGenreOrderChanges, setHasGenreOrderChanges] = useState(false)
+  
+  // ジャンル並び替えコンポーネントの参照
+  const genreOrderRef = useRef<GenreOrderCustomizerRef | null>(null)
   
   // NGリストが変更されたら一時リストも更新（モーダルを開いた時）
   useEffect(() => {
     if (isOpen) {
       setTempNGList(ngList)
       setHasChanges(false)
+      setHasGenreOrderChanges(false)
     }
   }, [isOpen, ngList])
   
@@ -153,23 +159,31 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
   
   // 適用処理
   const handleApply = () => {
-    // NGリストを保存（即座に反映される）
-    saveNGListDirectly(tempNGList)
-    
-    // onApplyコールバックがあれば呼び出す
-    if (onApply) {
-      onApply()
+    if (activeTab === 'nglist') {
+      // NGリストを保存（即座に反映される）
+      saveNGListDirectly(tempNGList)
+      
+      // onApplyコールバックがあれば呼び出す
+      if (onApply) {
+        onApply()
+      }
+      
+      // モーダルを閉じる
+      onClose()
+    } else if (activeTab === 'genre-order' && genreOrderRef.current) {
+      // ジャンル並び替えを適用（内部でリロード）
+      genreOrderRef.current.applyChanges()
     }
-    
-    // モーダルを閉じる
-    onClose()
   }
   
   // 閉じる処理
   const handleClose = () => {
-    if (hasChanges) {
+    if (hasChanges || hasGenreOrderChanges) {
       if (confirm('変更を破棄してもよろしいですか？')) {
         setTempNGList(ngList)  // 元に戻す
+        if (hasGenreOrderChanges && genreOrderRef.current) {
+          genreOrderRef.current.cancelChanges()
+        }
         onClose()
       }
     } else {
@@ -197,6 +211,12 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             onClick={() => setActiveTab('nglist')}
           >
             🚫 NGリスト管理
+          </button>
+          <button
+            className={`${styles.tab} ${activeTab === 'genre-order' ? styles.active : ''}`}
+            onClick={() => setActiveTab('genre-order')}
+          >
+            🎯 ジャンル並び替え
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'ng-backup' ? styles.active : ''}`}
@@ -438,6 +458,16 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
                 </div>
               </section>
             </div>
+          ) : activeTab === 'genre-order' ? (
+            <div className={styles.genreOrderSettings}>
+              <section className={styles.section}>
+                <h3>🎯 ジャンル並び替え</h3>
+                <GenreOrderCustomizer 
+                  ref={genreOrderRef}
+                  onChangesUpdate={setHasGenreOrderChanges}
+                />
+              </section>
+            </div>
           ) : (
             <div className={styles.ngBackupSettings}>
               <section className={styles.section}>
@@ -461,7 +491,7 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             )}
           </div>
           <div style={{ display: 'flex', gap: '8px' }}>
-            {activeTab === 'nglist' && hasChanges && (
+            {((activeTab === 'nglist' && hasChanges) || (activeTab === 'genre-order' && hasGenreOrderChanges)) && (
               <button 
                 className={styles.applyButton} 
                 onClick={handleApply}

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -205,7 +205,7 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             className={`${styles.tab} ${activeTab === 'display' ? styles.active : ''}`}
             onClick={() => setActiveTab('display')}
           >
-            🎨 表示
+            🎨 テーマ
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'nglist' ? styles.active : ''}`}

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -205,25 +205,25 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             className={`${styles.tab} ${activeTab === 'display' ? styles.active : ''}`}
             onClick={() => setActiveTab('display')}
           >
-            🎨 テーマ
+            <span style={{ whiteSpace: 'nowrap' }}>🎨&nbsp;テーマ</span>
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'nglist' ? styles.active : ''}`}
             onClick={() => setActiveTab('nglist')}
           >
-            🚫 NGリスト
+            <span style={{ whiteSpace: 'nowrap' }}>🚫&nbsp;NGリスト</span>
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'genre-order' ? styles.active : ''}`}
             onClick={() => setActiveTab('genre-order')}
           >
-            🎯 ジャンル
+            <span style={{ whiteSpace: 'nowrap' }}>🎯&nbsp;ジャンル</span>
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'ng-backup' ? styles.active : ''}`}
             onClick={() => setActiveTab('ng-backup')}
           >
-            💾 バックアップ
+            <span style={{ whiteSpace: 'nowrap' }}>💾&nbsp;バックアップ</span>
           </button>
         </div>
 

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useUserNGList, type UserNGList } from '@/hooks/use-user-ng-list'
 import { useUserPreferences, type ThemeType } from '@/hooks/use-user-preferences'
 import { NGBackup } from './ng-backup'
+import { GenreOrderBackup } from './genre-order-backup'
 import { GenreOrderCustomizer, type GenreOrderCustomizerRef } from './genre-order'
 import styles from './settings-modal.module.css'
 
@@ -222,7 +223,7 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             className={`${styles.tab} ${activeTab === 'ng-backup' ? styles.active : ''}`}
             onClick={() => setActiveTab('ng-backup')}
           >
-            💾 NGリスト保存
+            💾 設定データ保存
           </button>
         </div>
 
@@ -476,6 +477,14 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
                   現在適用されているNGリストをバックアップファイルとしてエクスポートしたり、他のデバイスからインポートできます。
                 </p>
                 <NGBackup />
+              </section>
+              
+              <section className={styles.section} style={{ marginTop: '2rem' }}>
+                <h3>🎯 ジャンル並び替えデータバックアップ</h3>
+                <p style={{ marginBottom: '1.5rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                  ジャンルの表示順序と表示/非表示設定をバックアップファイルとしてエクスポートしたり、他のデバイスからインポートできます。
+                </p>
+                <GenreOrderBackup />
               </section>
             </div>
           )}

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -205,25 +205,25 @@ export function SettingsModal({ isOpen, onClose, onApply }: SettingsModalProps) 
             className={`${styles.tab} ${activeTab === 'display' ? styles.active : ''}`}
             onClick={() => setActiveTab('display')}
           >
-            🎨 表示設定
+            🎨 表示
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'nglist' ? styles.active : ''}`}
             onClick={() => setActiveTab('nglist')}
           >
-            🚫 NGリスト管理
+            🚫 NGリスト
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'genre-order' ? styles.active : ''}`}
             onClick={() => setActiveTab('genre-order')}
           >
-            🎯 ジャンル並び替え
+            🎯 ジャンル
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'ng-backup' ? styles.active : ''}`}
             onClick={() => setActiveTab('ng-backup')}
           >
-            💾 設定データ保存
+            💾 バックアップ
           </button>
         </div>
 

--- a/hooks/use-genre-order-v2.ts
+++ b/hooks/use-genre-order-v2.ts
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { GenreItem, createDefaultGenreItems } from '@/types/genre-order'
+import { RankingGenre } from '@/types/ranking-config'
+
+const STORAGE_KEY = 'nicoRankingGenreOrder'
+
+/**
+ * ジャンル順序管理フック v2
+ * - シンプルな状態管理
+ * - 一時状態と永続化状態の明確な分離
+ * - 直感的なAPI
+ */
+export function useGenreOrderV2() {
+  // 永続化された状態
+  const [savedItems, setSavedItems] = useState<GenreItem[]>(() => {
+    if (typeof window === 'undefined') return createDefaultGenreItems()
+    
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored) as GenreItem[]
+        // 不正なデータのバリデーション
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load genre order:', error)
+    }
+    
+    return createDefaultGenreItems()
+  })
+
+  // 一時的な編集状態
+  const [tempItems, setTempItems] = useState<GenreItem[]>(savedItems)
+  const [hasChanges, setHasChanges] = useState(false)
+
+  // 保存済み状態が変更されたら一時状態も更新
+  useEffect(() => {
+    setTempItems(savedItems)
+    setHasChanges(false)
+  }, [savedItems])
+
+  // 変更検知
+  useEffect(() => {
+    const isChanged = JSON.stringify(tempItems) !== JSON.stringify(savedItems)
+    setHasChanges(isChanged)
+  }, [tempItems, savedItems])
+
+  /**
+   * 2つのアイテムの位置を入れ替える
+   */
+  const swapItems = useCallback((fromId: RankingGenre, toId: RankingGenre) => {
+    setTempItems(items => {
+      const newItems = [...items]
+      const fromIndex = newItems.findIndex(item => item.id === fromId)
+      const toIndex = newItems.findIndex(item => item.id === toId)
+      
+      if (fromIndex === -1 || toIndex === -1) return items
+      
+      // orderを入れ替える（表示状態は維持）
+      const tempOrder = newItems[fromIndex].order
+      newItems[fromIndex] = { ...newItems[fromIndex], order: newItems[toIndex].order }
+      newItems[toIndex] = { ...newItems[toIndex], order: tempOrder }
+      
+      // order順でソート
+      return newItems.sort((a, b) => a.order - b.order)
+    })
+  }, [])
+
+  /**
+   * 表示/非表示を切り替える
+   */
+  const toggleVisibility = useCallback((id: RankingGenre) => {
+    setTempItems(items => 
+      items.map(item => 
+        item.id === id 
+          ? { ...item, isVisible: !item.isVisible }
+          : item
+      )
+    )
+  }, [])
+
+  /**
+   * デフォルトに戻す
+   */
+  const resetToDefault = useCallback(() => {
+    setTempItems(createDefaultGenreItems())
+  }, [])
+
+  /**
+   * 変更を適用してLocalStorageに保存
+   */
+  const applyChanges = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(tempItems))
+      setSavedItems(tempItems)
+      setHasChanges(false)
+      
+      // ページリロードで変更を反映
+      window.location.reload()
+    } catch (error) {
+      console.error('Failed to save genre order:', error)
+      throw error
+    }
+  }, [tempItems])
+
+  /**
+   * 変更を破棄
+   */
+  const cancelChanges = useCallback(() => {
+    setTempItems(savedItems)
+    setHasChanges(false)
+  }, [savedItems])
+
+  /**
+   * 現在の表示順序（表示されているもののみ）
+   */
+  const visibleGenres = tempItems
+    .filter(item => item.isVisible)
+    .sort((a, b) => a.order - b.order)
+    .map(item => item.id)
+
+  /**
+   * 現在の非表示リスト
+   */
+  const hiddenGenres = tempItems
+    .filter(item => !item.isVisible)
+    .map(item => item.id)
+
+  return {
+    // 状態
+    items: tempItems,
+    visibleGenres,
+    hiddenGenres,
+    hasChanges,
+    
+    // 操作
+    swapItems,
+    toggleVisibility,
+    resetToDefault,
+    applyChanges,
+    cancelChanges
+  }
+}

--- a/hooks/use-genre-order-v2.ts
+++ b/hooks/use-genre-order-v2.ts
@@ -50,23 +50,29 @@ export function useGenreOrderV2() {
   }, [tempItems, savedItems])
 
   /**
-   * 2つのアイテムの位置を入れ替える
+   * アイテムを新しい位置に移動する（Insert方式）
+   * ドラッグしたアイテムを新しい位置に挿入し、他のアイテムは順番を保ちながらシフト
    */
-  const swapItems = useCallback((fromId: RankingGenre, toId: RankingGenre) => {
+  const moveItem = useCallback((fromId: RankingGenre, toId: RankingGenre) => {
     setTempItems(items => {
       const newItems = [...items]
       const fromIndex = newItems.findIndex(item => item.id === fromId)
       const toIndex = newItems.findIndex(item => item.id === toId)
       
-      if (fromIndex === -1 || toIndex === -1) return items
+      if (fromIndex === -1 || toIndex === -1 || fromIndex === toIndex) return items
       
-      // orderを入れ替える（表示状態は維持）
-      const tempOrder = newItems[fromIndex].order
-      newItems[fromIndex] = { ...newItems[fromIndex], order: newItems[toIndex].order }
-      newItems[toIndex] = { ...newItems[toIndex], order: tempOrder }
+      // ドラッグされたアイテムを取り出す
+      const [draggedItem] = newItems.splice(fromIndex, 1)
       
-      // order順でソート
-      return newItems.sort((a, b) => a.order - b.order)
+      // 新しい位置に挿入
+      newItems.splice(toIndex, 0, draggedItem)
+      
+      // orderを再計算
+      newItems.forEach((item, index) => {
+        item.order = index
+      })
+      
+      return newItems
     })
   }, [])
 
@@ -138,7 +144,7 @@ export function useGenreOrderV2() {
     hasChanges,
     
     // 操作
-    swapItems,
+    moveItem,
     toggleVisibility,
     resetToDefault,
     applyChanges,

--- a/hooks/use-genre-order.ts
+++ b/hooks/use-genre-order.ts
@@ -1,0 +1,35 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useGenreOrderV2 } from './use-genre-order-v2'
+import { RankingGenre } from '@/types/ranking-config'
+
+/**
+ * ジャンル順序管理フック
+ * useGenreOrderV2の簡易ラッパーとして機能し、
+ * 既存のコンポーネントで使用できるインターフェースを提供
+ */
+export function useGenreOrder() {
+  const { visibleGenres, hiddenGenres } = useGenreOrderV2()
+  
+  return useMemo(() => ({
+    // 表示されているジャンルの順序
+    order: visibleGenres,
+    
+    // 非表示のジャンルのセット
+    hidden: new Set(hiddenGenres),
+    
+    // 後方互換性のためのメソッド（実際の更新はGenreOrderCustomizerで行う）
+    updateOrder: (newOrder: RankingGenre[]) => {
+      console.warn('updateOrder is deprecated. Use GenreOrderCustomizer component.')
+    },
+    
+    toggleGenreVisibility: (genre: RankingGenre) => {
+      console.warn('toggleGenreVisibility is deprecated. Use GenreOrderCustomizer component.')
+    },
+    
+    resetToDefault: () => {
+      console.warn('resetToDefault is deprecated. Use GenreOrderCustomizer component.')
+    }
+  }), [visibleGenres, hiddenGenres])
+}

--- a/types/genre-order.ts
+++ b/types/genre-order.ts
@@ -1,0 +1,39 @@
+import { RankingGenre } from './ranking-config'
+
+/**
+ * ジャンルアイテムの情報
+ */
+export interface GenreItem {
+  id: RankingGenre
+  isVisible: boolean
+  order: number
+}
+
+/**
+ * ジャンル順序の状態
+ */
+export interface GenreOrderState {
+  items: GenreItem[]
+}
+
+/**
+ * デフォルトのジャンル順序
+ */
+export const DEFAULT_GENRE_ORDER: RankingGenre[] = [
+  'all', 'game', 'anime', 'vocaloid', 'voicesynthesis', 
+  'entertainment', 'music', 'sing', 'dance', 'play', 
+  'commentary', 'cooking', 'travel', 'nature', 'vehicle', 
+  'technology', 'society', 'mmd', 'vtuber', 'radio', 
+  'sports', 'animal', 'other'
+]
+
+/**
+ * デフォルトのジャンル状態を生成
+ */
+export function createDefaultGenreItems(): GenreItem[] {
+  return DEFAULT_GENRE_ORDER.map((id, index) => ({
+    id,
+    isVisible: true,
+    order: index
+  }))
+}


### PR DESCRIPTION
## 概要
ジャンル並び替え機能を完全に再実装しました。

## 主な変更点

### ✨ 新機能
- ドラッグ&ドロップによるジャンル順序の変更
- 表示/非表示の個別切り替え
- デフォルトに戻す機能
- 変更の一時保存と適用/キャンセル機能

### 🏗️ アーキテクチャ改善
- 新しいデータ構造 `GenreItem` の導入
- 一時状態と永続状態の明確な分離
- カスタムフック `useGenreOrderV2` による状態管理
- 既存コードとの互換性レイヤー

### 🐛 修正された問題
- ドラッグ&ドロップが表示状態を変更してしまう問題
- デフォルトリセットの挙動の問題
- 複雑な状態管理による混乱

## テスト
- ✅ 単体テスト追加
- ✅ 統合テスト追加
- ✅ すべてのテストが合格

## 今後の改善予定
- キーボードショートカット対応
- アニメーション改善
- モバイル対応の最適化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a customizable genre order feature accessible via a new tab in the settings modal, allowing users to reorder and toggle the visibility of genres with drag-and-drop and visibility controls.
  * Added the ability to reset genre order to default, apply or cancel changes, and receive confirmation prompts for unsaved changes.
  * Genre selector now dynamically displays only visible genres as configured by the user.
  * Added export and import functionality for genre order settings, enabling users to back up and restore their custom configurations.

* **Style**
  * Added new styles for the genre order customizer, including drag-and-drop effects, visibility toggles, and action buttons.
  * Updated settings modal styles to accommodate the new genre order tab.
  * Added styles for the genre order backup and import dialogs.

* **Tests**
  * Added comprehensive integration and unit tests for the genre order customization feature, including UI interactions and state management.
  * Added tests for genre order backup import/export functionality.

* **Bug Fixes**
  * Removed user prompts and automatic page reloads after NG list import, improving import experience by reflecting updates immediately without requiring reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->