### PR TITLE
feat: ユーザータグ表示機能の実装（getthumbinfo APIベース）

### DIFF
--- a/components/ranking-item-responsive.tsx
+++ b/components/ranking-item-responsive.tsx
@@ -373,7 +373,7 @@ const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabl
           </div>
           
           {/* タグ情報 */}
-          {showTags && item.tags && item.tags.length > 0 && (
+          {showTags && ((item.tags && item.tags.length > 0) || (item.tagDetails && item.tagDetails.length > 0)) && (
             <div 
               className="ranking-item-responsive__tags"
               style={{
@@ -385,31 +385,85 @@ const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabl
                 borderTop: '1px solid var(--border-color)'
               }}
             >
-              {item.tags.slice(0, 8).map((tag, index) => (
-                <span
-                  key={index}
-                  style={{
-                    background: 'var(--surface-secondary)',
-                    color: 'var(--text-secondary)',
-                    fontSize: '11px',
-                    padding: '4px 10px',
-                    borderRadius: '14px',
-                    border: '1px solid var(--border-color)',
-                    whiteSpace: 'nowrap',
-                    maxWidth: '120px',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    display: 'inline-block',
-                    verticalAlign: 'middle',
-                    lineHeight: '12px',
-                    boxSizing: 'border-box'
-                  }}
-                  title={tag}
-                >
-                  {tag}
-                </span>
-              ))}
-              {item.tags.length > 8 && (
+              {/* タグ詳細がある場合は詳細を使用、ない場合は従来のタグを使用 */}
+              {item.tagDetails && item.tagDetails.length > 0 ? (
+                item.tagDetails.slice(0, 8).map((tagDetail, index) => (
+                  <span
+                    key={index}
+                    style={{
+                      background: 'var(--surface-secondary)',
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      padding: '4px 6px 4px 8px',
+                      borderRadius: '14px',
+                      border: '1px solid var(--border-color)',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '120px',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                      lineHeight: '12px',
+                      boxSizing: 'border-box'
+                    }}
+                    title={tagDetail.name}
+                  >
+                    {/* タグアイコン */}
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      style={{ flexShrink: 0 }}
+                    >
+                      {tagDetail.isLocked ? (
+                        // ロックタグ用の金色の鍵アイコン
+                        <path
+                          d="M12 2C9.79 2 8 3.79 8 6V8H6C4.9 8 4 8.9 4 10V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V10C20 8.9 19.1 8 18 8H16V6C16 3.79 14.21 2 12 2ZM12 4C13.1 4 14 4.9 14 6V8H10V6C10 4.9 10.9 4 12 4ZM12 13C13.1 13 14 13.9 14 15C14 16.1 13.1 17 12 17C10.9 17 10 16.1 10 15C10 13.9 10.9 13 12 13Z"
+                          fill="#FFD700"
+                        />
+                      ) : (
+                        // ユーザータグ用の銀色のタグアイコン
+                        <path
+                          d="M21.41 11.58L12.41 2.58C12.05 2.22 11.55 2 11 2H4C2.9 2 2 2.9 2 4V11C2 11.55 2.22 12.05 2.59 12.42L11.59 21.42C11.95 21.78 12.45 22 13 22C13.55 22 14.05 21.78 14.41 21.41L21.41 14.41C21.78 14.05 22 13.55 22 13C22 12.45 21.77 11.94 21.41 11.58ZM5.5 7C4.67 7 4 6.33 4 5.5C4 4.67 4.67 4 5.5 4C6.33 4 7 4.67 7 5.5C7 6.33 6.33 7 5.5 7Z"
+                          fill="#C0C0C0"
+                        />
+                      )}
+                    </svg>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                      {tagDetail.name}
+                    </span>
+                  </span>
+                ))
+              ) : (
+                // 従来のタグ表示（後方互換性）
+                item.tags?.slice(0, 8).map((tag, index) => (
+                  <span
+                    key={index}
+                    style={{
+                      background: 'var(--surface-secondary)',
+                      color: 'var(--text-secondary)',
+                      fontSize: '11px',
+                      padding: '4px 10px',
+                      borderRadius: '14px',
+                      border: '1px solid var(--border-color)',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '120px',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: 'inline-block',
+                      verticalAlign: 'middle',
+                      lineHeight: '12px',
+                      boxSizing: 'border-box'
+                    }}
+                    title={tag}
+                  >
+                    {tag}
+                  </span>
+                ))
+              )}
+              {(item.tagDetails ? item.tagDetails.length > 8 : item.tags && item.tags.length > 8) && (
                 <span
                   style={{
                     color: 'var(--text-secondary)',
@@ -417,7 +471,7 @@ const RankingItemResponsive = memo(function RankingItemResponsive({ item, disabl
                     padding: '2px 6px'
                   }}
                 >
-                  +{item.tags.length - 8}
+                  +{item.tagDetails ? item.tagDetails.length - 8 : (item.tags ? item.tags.length - 8 : 0)}
                 </span>
               )}
             </div>

--- a/lib/tag-fetcher-simple.ts
+++ b/lib/tag-fetcher-simple.ts
@@ -6,6 +6,14 @@
 import type { RankingItem } from '../types/ranking'
 
 /**
+ * タグの詳細情報
+ */
+export interface TagDetail {
+  name: string
+  isLocked: boolean
+}
+
+/**
  * getthumbinfo APIを使用して固定タグを取得
  * @param videoId 動画ID
  * @returns 固定タグの配列、取得できない場合は空配列
@@ -35,6 +43,49 @@ export async function fetchFixedTagsFromGetThumbInfo(videoId: string): Promise<s
     const lockedTags = Array.from(lockedTagMatches, m => m[1])
     
     return lockedTags
+  } catch (error) {
+    // エラーは静かに処理（ログ出力なし）
+    return []
+  }
+}
+
+/**
+ * getthumbinfo APIを使用してすべてのタグ（ロックタグ＋ユーザータグ）を取得
+ * @param videoId 動画ID
+ * @returns タグ詳細の配列、取得できない場合は空配列
+ */
+export async function fetchAllTagsFromGetThumbInfo(videoId: string): Promise<TagDetail[]> {
+  try {
+    const response = await fetch(`https://ext.nicovideo.jp/api/getthumbinfo/${videoId}`)
+    
+    if (!response.ok) {
+      return []
+    }
+    
+    const xml = await response.text()
+    
+    // エラーレスポンスのチェック
+    if (xml.includes('status="fail"')) {
+      return []
+    }
+    
+    // 成功レスポンスのチェック
+    if (!xml.includes('status="ok"')) {
+      return []
+    }
+    
+    // すべてのタグを抽出（ロック状態も含む）
+    const allTagMatches = xml.matchAll(/<tag(\s+lock="1")?[^>]*>([^<]+)<\/tag>/g)
+    const tagDetails: TagDetail[] = []
+    
+    for (const match of allTagMatches) {
+      tagDetails.push({
+        name: match[2],
+        isLocked: match[1] !== undefined
+      })
+    }
+    
+    return tagDetails
   } catch (error) {
     // エラーは静かに処理（ログ出力なし）
     return []
@@ -112,6 +163,81 @@ export async function enrichRankingItemsWithFixedTags(
   // eslint-disable-next-line no-console
   console.log(
     `[Tag Fetching] Completed: ${totalItems} items in ${elapsed}s, ` +
+    `${itemsWithTags} items with tags (${Math.round(itemsWithTags / totalItems * 100)}%)`
+  )
+  
+  return enrichedItems
+}
+
+
+/**
+ * 複数のランキングアイテムに対してタグ詳細を一括取得
+ * @param items ランキングアイテムの配列
+ * @param parallelCount 並列処理数（デフォルト: 50、getthumbinfo APIは軽量）
+ * @param batchDelay バッチ間の遅延（ミリ秒、デフォルト: 50）
+ * @returns タグ詳細情報が追加されたランキングアイテムの配列
+ */
+export async function enrichRankingItemsWithTagDetails(
+  items: RankingItem[],
+  parallelCount: number = 50,
+  batchDelay: number = 50
+): Promise<(RankingItem & { tagDetails?: TagDetail[] })[]> {
+  const totalItems = items.length
+  const startTime = Date.now()
+  let processedCount = 0
+  let itemsWithTags = 0
+  
+  // バッチ処理
+  const enrichedItems: (RankingItem & { tagDetails?: TagDetail[] })[] = []
+  
+  for (let i = 0; i < items.length; i += parallelCount) {
+    const batch = items.slice(i, i + parallelCount)
+    
+    const batchPromises = batch.map(async (item) => {
+      const tagDetails = await fetchAllTagsFromGetThumbInfo(item.id)
+      
+      if (tagDetails.length > 0) {
+        itemsWithTags++
+      }
+      
+      return {
+        ...item,
+        tagDetails,
+        // 後方互換性のため、既存のtagsフィールドも更新
+        tags: tagDetails.map(t => t.name)
+      }
+    })
+    
+    const batchResults = await Promise.all(batchPromises)
+    enrichedItems.push(...batchResults)
+    
+    processedCount += batch.length
+    
+    // 進捗表示（10%ごと）
+    const progress = Math.floor((processedCount / totalItems) * 10) * 10
+    if (progress > 0 && processedCount % Math.floor(totalItems / 10) < parallelCount) {
+      const elapsed = Date.now() - startTime
+      const avgTime = elapsed / processedCount
+      const remainingTime = Math.round((totalItems - processedCount) * avgTime / 1000)
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Tag Details Fetching] ${progress}% complete (${processedCount}/${totalItems}), ` +
+        `${itemsWithTags} items with tags, ` +
+        `ETA: ${remainingTime}s`
+      )
+    }
+    
+    // バッチ間の遅延（最後のバッチ以外）
+    if (i + parallelCount < items.length) {
+      await new Promise(resolve => setTimeout(resolve, batchDelay))
+    }
+  }
+  
+  // 最終統計
+  const elapsed = Math.round((Date.now() - startTime) / 1000)
+  // eslint-disable-next-line no-console
+  console.log(
+    `[Tag Details Fetching] Completed: ${totalItems} items in ${elapsed}s, ` +
     `${itemsWithTags} items with tags (${Math.round(itemsWithTags / totalItems * 100)}%)`
   )
   

--- a/scripts/update-ranking-parallel-v2.ts
+++ b/scripts/update-ranking-parallel-v2.ts
@@ -2,7 +2,7 @@
 import type { RankingGenre } from '../types/ranking-config'
 import type { RankingItem } from '../types/ranking'
 import { kv } from '../lib/simple-kv'
-import { enrichRankingItemsWithFixedTags } from '../lib/tag-fetcher-simple'
+import { enrichRankingItemsWithTagDetails } from '../lib/tag-fetcher-simple'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 
@@ -480,16 +480,16 @@ async function processGenre(
   const enableTagFetchingForTagRankings = process.env.TAG_FETCH_FOR_TAG_RANKINGS === 'true';
   
   if (enableTagFetching) {
-    console.log(`[${new Date().toISOString()}] Fixed tag fetching enabled for ${genre}: maxVideos=${tagFetchMaxVideos}, tagRankings=${enableTagFetchingForTagRankings}`);
+    console.log(`[${new Date().toISOString()}] Tag details fetching enabled for ${genre}: maxVideos=${tagFetchMaxVideos}, tagRankings=${enableTagFetchingForTagRankings}`);
   }
   
   if (enableTagFetching && (tagFetchGenres.length === 0 || tagFetchGenres.includes(genre))) {
-    console.log(`[${new Date().toISOString()}] Fetching fixed tags for ${genre}...`);
+    console.log(`[${new Date().toISOString()}] Fetching tag details for ${genre}...`);
     
     // Fetch tags for 24h data
     if (data24h.items.length > 0) {
       const itemsToFetch = data24h.items.slice(0, tagFetchMaxVideos);
-      const itemsWithTags = await enrichRankingItemsWithFixedTags(itemsToFetch);
+      const itemsWithTags = await enrichRankingItemsWithTagDetails(itemsToFetch);
       // Merge tagged items with remaining untagged items to preserve full array
       data24h.items = [...itemsWithTags, ...data24h.items.slice(tagFetchMaxVideos)];
     }
@@ -497,7 +497,7 @@ async function processGenre(
     // Fetch tags for hour data
     if (dataHour.items.length > 0) {
       const itemsToFetch = dataHour.items.slice(0, tagFetchMaxVideos);
-      const itemsWithTags = await enrichRankingItemsWithFixedTags(itemsToFetch);
+      const itemsWithTags = await enrichRankingItemsWithTagDetails(itemsToFetch);
       // Merge tagged items with remaining untagged items to preserve full array
       dataHour.items = [...itemsWithTags, ...dataHour.items.slice(tagFetchMaxVideos)];
     }
@@ -539,20 +539,20 @@ async function processGenre(
         
         // Apply fixed tags to tag rankings if enabled
         if (enableTagFetching && enableTagFetchingForTagRankings) {
-          console.log(`[${new Date().toISOString()}] Enriching tag "${tag}" with fixed tags (24h: ${tag24h.items.length}, hour: ${tagHour.items.length} items)`);
+          console.log(`[${new Date().toISOString()}] Enriching tag "${tag}" with tag details (24h: ${tag24h.items.length}, hour: ${tagHour.items.length} items)`);
           
           if (tag24h.items.length > 0) {
-            const itemsWithTags24h = await enrichRankingItemsWithFixedTags(tag24h.items);
+            const itemsWithTags24h = await enrichRankingItemsWithTagDetails(tag24h.items);
             result.data['24h'].tags[tag] = itemsWithTags24h;
-            console.log(`[${new Date().toISOString()}] Enriched tag "${tag}" 24h with fixed tags`);
+            console.log(`[${new Date().toISOString()}] Enriched tag "${tag}" 24h with tag details`);
           } else {
             result.data['24h'].tags[tag] = tag24h.items;
           }
           
           if (tagHour.items.length > 0) {
-            const itemsWithTagsHour = await enrichRankingItemsWithFixedTags(tagHour.items);
+            const itemsWithTagsHour = await enrichRankingItemsWithTagDetails(tagHour.items);
             result.data['hour'].tags[tag] = itemsWithTagsHour;
-            console.log(`[${new Date().toISOString()}] Enriched tag "${tag}" hour with fixed tags`);
+            console.log(`[${new Date().toISOString()}] Enriched tag "${tag}" hour with tag details`);
           } else {
             result.data['hour'].tags[tag] = tagHour.items;
           }

--- a/types/ranking.ts
+++ b/types/ranking.ts
@@ -1,3 +1,11 @@
+/**
+ * タグの詳細情報
+ */
+export interface TagDetail {
+  name: string
+  isLocked: boolean
+}
+
 export interface RankingItem {
   rank: number
   id: string
@@ -9,6 +17,7 @@ export interface RankingItem {
   likes?: number
   // 拡張フィールド（スクレイピング用）
   tags?: string[]
+  tagDetails?: TagDetail[]  // タグの詳細情報（ロック状態を含む）
   authorId?: string
   authorName?: string
   authorIcon?: string


### PR DESCRIPTION
## 概要
getthumbinfo APIを使用してロックタグとユーザータグの両方を取得・表示する機能を実装しました。

## 変更内容
- `fetchAllTagsFromGetThumbInfo()`関数を追加
- UIでロックタグ（金色の鍵アイコン）とユーザータグ（銀色のタグアイコン）を区別表示
- `enrichRankingItemsWithTagDetails()`をgetthumbinfo APIベースに変更
- Watch API実装を削除（不要）

## パフォーマンス向上
- 並列数: 10→50（getthumbinfo APIは軽量）
- バッチ遅延: 200ms→50ms

## 確認事項
- [x] コード変更完了
- [x] 環境変数はデフォルトで有効（`ENABLE_TAG_FETCHING=true`）
- [ ] cronジョブ実行後に動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)