### PR TITLE
fix: キャッシュ戦略とレート制限を修正して429エラーを解決

### DIFF
--- a/deploy-preview-test.sh
+++ b/deploy-preview-test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Preview Environment Deployment and Test Script
+# 2025-08-08
+
+set -e
+
+echo "========================================="
+echo "Preview Environment Deployment & Testing"
+echo "========================================="
+echo ""
+
+# Step 1: Deploy Green Worker to preview
+echo "📦 Step 1: Deploying Green Worker..."
+echo "Command: wrangler deploy -c workers/wrangler-green.toml --name nico-ranking-api-gateway-green-preview"
+wrangler deploy -c workers/wrangler-green.toml --name nico-ranking-api-gateway-green-preview
+
+echo ""
+echo "⏳ Waiting for deployment to propagate..."
+sleep 5
+
+# Step 2: Get preview URL
+PREVIEW_URL="https://nico-ranking-api-gateway-preview.5984977746a3dfcd71415bed5c324eb1.workers.dev"
+echo "🌐 Preview URL: $PREVIEW_URL"
+echo ""
+
+# Step 3: Test debug endpoint
+echo "🔍 Step 3: Testing debug endpoint..."
+echo "curl $PREVIEW_URL/api/debug"
+curl -s "$PREVIEW_URL/api/debug" | jq '.worker, .version, .features' || echo "Debug endpoint failed"
+echo ""
+
+# Step 4: Test normal ranking (should work)
+echo "✅ Step 4: Testing normal ranking (genre=all)..."
+NORMAL_RESPONSE=$(curl -s -I "$PREVIEW_URL/api/ranking?genre=all")
+echo "$NORMAL_RESPONSE" | grep -E "HTTP|Cache-Control|X-Data-Source"
+echo ""
+
+# Step 5: Test tag ranking with existing tag
+echo "🏷️ Step 5: Testing existing tag ranking..."
+# Common tags that likely exist
+for tag in "ゲーム" "アニメ" "音楽" "VOCALOID"; do
+    echo "Testing tag: $tag"
+    TAG_RESPONSE=$(curl -s "$PREVIEW_URL/api/ranking?genre=all&tag=$tag")
+    ITEM_COUNT=$(echo "$TAG_RESPONSE" | jq '.items | length' 2>/dev/null || echo "0")
+    if [ "$ITEM_COUNT" != "0" ]; then
+        echo "✅ Tag '$tag' found: $ITEM_COUNT items"
+        break
+    else
+        echo "❌ Tag '$tag' not found or empty"
+    fi
+done
+echo ""
+
+# Step 6: Test non-existent tag (should be cached now)
+echo "🚫 Step 6: Testing non-existent tag caching..."
+NONEXIST_TAG="this_tag_definitely_does_not_exist_12345"
+echo "First request for non-existent tag: $NONEXIST_TAG"
+RESPONSE1=$(curl -s -I "$PREVIEW_URL/api/ranking?genre=all&tag=$NONEXIST_TAG")
+CACHE_CONTROL=$(echo "$RESPONSE1" | grep -i "cache-control:" || echo "No cache header")
+echo "Cache-Control: $CACHE_CONTROL"
+
+if echo "$CACHE_CONTROL" | grep -q "max-age=300"; then
+    echo "✅ Non-existent tag responses are now cached!"
+else
+    echo "⚠️ Cache headers may not be properly set"
+fi
+echo ""
+
+# Step 7: Check R2 data structure
+echo "📊 Step 7: Checking R2 data availability..."
+echo "Testing metadata endpoint..."
+METADATA=$(curl -s "$PREVIEW_URL/api/metadata")
+if echo "$METADATA" | jq . >/dev/null 2>&1; then
+    echo "✅ Metadata endpoint working"
+    echo "$METADATA" | jq '{version, lastUpdated}' 2>/dev/null || echo "$METADATA"
+else
+    echo "⚠️ Metadata endpoint may have issues"
+fi
+echo ""
+
+# Step 8: Rate limiting test
+echo "🚦 Step 8: Testing rate limiting..."
+echo "Sending 5 rapid requests..."
+for i in {1..5}; do
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PREVIEW_URL/api/ranking?genre=all&test=$i")
+    echo -n "$STATUS "
+    sleep 0.2
+done
+echo ""
+echo ""
+
+# Step 9: Summary
+echo "========================================="
+echo "📝 Summary & Next Steps"
+echo "========================================="
+echo ""
+echo "✅ Deployment completed to preview environment"
+echo ""
+echo "Key URLs:"
+echo "- Preview: $PREVIEW_URL"
+echo "- Main site: https://nico-rank.com"
+echo ""
+echo "To verify R2 tag data:"
+echo "1. Check if common tags return data (ゲーム, アニメ, etc.)"
+echo "2. Check CloudFlare dashboard → R2 → nico-ranking bucket"
+echo "3. Look for: rankings/{genre}/{period}/tags/*.json files"
+echo ""
+echo "Monitor in CloudFlare dashboard:"
+echo "- Workers & Pages → nico-ranking-api-gateway-green-preview"
+echo "- Analytics → Cache Analysis"
+echo "- Security → Events (for rate limiting)"
+echo ""
+echo "If everything works in preview:"
+echo "1. Update KV: active_worker = 'green'"
+echo "2. Or deploy directly: wrangler deploy -c workers/wrangler-green.toml"

--- a/workers/api-gateway-green-20250726.ts
+++ b/workers/api-gateway-green-20250726.ts
@@ -445,6 +445,12 @@ export default {
     
     // /api/ranking パスの処理
     if (url.pathname === '/api/ranking' && env.R2_BUCKET) {
+      // レート制限チェック（ランキングAPI用）
+      const rateLimitCheck = await checkRateLimit(request, env, 'ranking')
+      if (!rateLimitCheck.success) {
+        return rateLimitCheck.error!
+      }
+      
       const genre = url.searchParams.get('genre') || 'all'
       const period = url.searchParams.get('period') || '24h'
       const tag = url.searchParams.get('tag') || ''
@@ -479,9 +485,11 @@ export default {
               status: 200,
               headers: {
                 'Content-Type': 'application/json',
-                'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+                // タグが見つからない場合も短時間キャッシュ（5分）して負荷軽減
+                'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=60',
                 'X-Data-Source': 'r2-tag-not-found',
-                'X-Worker-Version': 'green-20250726-unified-cors'
+                'X-Worker-Version': 'green-20250726-unified-cors',
+                'X-Cache-Note': 'Tag not found - cached for 5 minutes to reduce load'
               }
             })
             
@@ -497,7 +505,8 @@ export default {
               status: 404,
               headers: {
                 'Content-Type': 'application/json',
-                'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+                // 404エラーも短時間キャッシュして負荷軽減
+                'Cache-Control': 'public, max-age=60, s-maxage=60',
                 'X-Data-Source': 'r2-not-found',
                 'X-Worker-Version': 'green-20250726-unified-cors'
               }
@@ -640,7 +649,8 @@ export default {
           status: 500,
           headers: {
             'Content-Type': 'application/json',
-            'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+            // エラー時も短時間キャッシュ
+            'Cache-Control': 'public, max-age=30, s-maxage=30',
             'X-Worker-Version': 'green-20250726-unified-cors'
           }
         })


### PR DESCRIPTION
## 🔧 修正内容

本番環境で発生している3つの問題を修正しました：

### 問題
1. **キャッシュ無効化による過負荷** - 存在しないタグへのリクエストが`no-cache`で全てオリジンに到達
2. **レート制限の未適用** - `/api/ranking`エンドポイントに制限なし  
3. **CloudflareのWAF未設定** - DDoS保護が機能していない

### 解決策
- ✅ タグ未存在時も5分間キャッシュ（`Cache-Control: public, max-age=300`）
- ✅ `/api/ranking`にレート制限適用（20req/分）
- ✅ エラーレスポンスも短時間キャッシュ（30-60秒）

### 変更ファイル
- `workers/api-gateway-green-20250726.ts` - キャッシュヘッダーとレート制限の修正

## ⚠️ 重要：確認方法について

**VercelのプレビューURLでは確認できません**  
理由：今回の修正はCloudflare Workers側なので、Vercelプレビューには反映されません。

### 確認方法

#### 1. Cloudflare Workers側でのテスト（推奨）
```bash
# ローカルテスト
wrangler dev -c workers/wrangler-green.toml
./scripts/test-cache-fix.sh http://localhost:8787

# Workers Previewへデプロイ
wrangler deploy -c workers/wrangler-green.toml --env preview
```

#### 2. 本番環境への適用手順
1. このPRをマージ
2. Cloudflare Workersをデプロイ：
   ```bash
   wrangler deploy -c workers/wrangler-green.toml
   ```
3. KVで`active_worker`を`green`に設定
4. CloudflareダッシュボードでWAF設定

### モニタリング項目
- キャッシュヒット率（目標: 80%以上）
- 429エラー率（目標: 1%未満）

## アーキテクチャ図
```
[ユーザー] → [Cloudflare Workers（修正箇所）] → [Vercel/Next.js]
                    ↓
                  [R2/KV]
```

---
**Note**: VercelとCloudflare Workersは独立してデプロイされるため、このPRのマージ後にWorkers側の手動デプロイが必要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an automated script to deploy and test a preview environment, including endpoint checks, cache validation, and rate limiting tests.
* **Bug Fixes**
  * Applied rate limiting to the ranking API endpoint to prevent excessive requests.
* **Refactor**
  * Updated cache-control headers for ranking API responses to allow short-term public caching, including improved handling for missing data and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->