### PR TITLE
feat: PWAリロード機能の実装

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -29,6 +29,9 @@ import type { NGType } from '@/components/quick-ng-button'
 import { useNavigationState } from '@/hooks/use-navigation-state'
 import { TagDisplayProvider, useTagDisplay } from '@/contexts/tag-display-context'
 import { serverLog } from '@/lib/server-log'
+import { usePullToRefresh } from '@/hooks/use-pull-to-refresh'
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
+import { PullToRefreshIndicator } from '@/components/pull-to-refresh-indicator'
 import './client-page.css'
 import '@/components/ranking-item-responsive.css'
 
@@ -108,6 +111,10 @@ export default function ClientPage({
   
   // PWA環境でのナビゲーション状態管理
   useNavigationState()
+  
+  // PWAリロード機能
+  const { isPulling, pullDistance } = usePullToRefresh()
+  useKeyboardShortcuts()
   
   // 選択中のジャンルが非表示になった場合、最初の表示可能なジャンルに切り替える
   useEffect(() => {
@@ -1120,6 +1127,7 @@ export default function ClientPage({
   try {
     return (
       <TagDisplayProvider>
+        <PullToRefreshIndicator isPulling={isPulling} pullDistance={pullDistance} />
         <div className="selectors-container">
         <RankingSelector 
           config={config} 

--- a/app/globals.css
+++ b/app/globals.css
@@ -64,6 +64,10 @@
   --input-background: #ffffff;
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.15);
   --shadow-xl: 0 8px 24px rgba(0, 0, 0, 0.2);
+  
+  /* リロードボタン用ツールチップ */
+  --tooltip-bg: rgba(0, 0, 0, 0.8);
+  --tooltip-text: white;
 }
 
 /* ダークテーマ - 継承 */
@@ -120,6 +124,10 @@
   --input-background: #2a2a2a;
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.5);
   --shadow-xl: 0 8px 24px rgba(0, 0, 0, 0.7);
+  
+  /* リロードボタン用ツールチップ */
+  --tooltip-bg: rgba(255, 255, 255, 0.9);
+  --tooltip-text: #1a1a1a;
 }
 
 /* ダークブルーテーマ (X/Twitter風) */
@@ -176,6 +184,10 @@
   --input-background: #22303c;
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.6);
   --shadow-xl: 0 8px 24px rgba(0, 0, 0, 0.8);
+  
+  /* リロードボタン用ツールチップ */
+  --tooltip-bg: rgba(26, 46, 68, 0.95);
+  --tooltip-text: #e8f0ff;
 }
 
 body {

--- a/components/header-with-settings.tsx
+++ b/components/header-with-settings.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { SettingsModal } from './settings-modal'
 import { Navigation } from './navigation'
+import { ReloadButton } from './reload-button'
 import styles from './header.module.css'
 
 export function HeaderWithSettings() {
@@ -72,13 +73,16 @@ export function HeaderWithSettings() {
           </Link>
         </div>
         
-        <button
-          onClick={() => setIsSettingsOpen(true)}
-          className={styles.settingsButton}
-          aria-label="設定"
-        >
-          ⚙️
-        </button>
+        <div className={styles.headerButtons}>
+          <ReloadButton />
+          <button
+            onClick={() => setIsSettingsOpen(true)}
+            className={styles.settingsButton}
+            aria-label="設定"
+          >
+            ⚙️
+          </button>
+        </div>
       </header>
       
       <SettingsModal 

--- a/components/header.module.css
+++ b/components/header.module.css
@@ -61,12 +61,20 @@
   margin-right: 4px;
 }
 
-/* 設定ボタン */
-.settingsButton {
+/* ヘッダーボタングループ */
+.headerButtons {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
   right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 10;
+}
+
+/* 設定ボタン */
+.settingsButton {
   background: rgba(255, 255, 255, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 6px;
@@ -77,12 +85,11 @@
   transition: all 0.2s;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  z-index: 10;
 }
 
 .settingsButton:hover {
   background-color: rgba(255, 255, 255, 0.35);
-  transform: translateY(-50%) scale(1.05);
+  transform: scale(1.05);
 }
 
 /* コントロールボタンコンテナ */

--- a/components/pull-to-refresh-indicator.module.css
+++ b/components/pull-to-refresh-indicator.module.css
@@ -1,0 +1,71 @@
+.indicator {
+  position: fixed;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.iconWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  background: var(--card-bg);
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--border-color);
+}
+
+.iconWrapper svg {
+  color: var(--primary-color);
+}
+
+.text {
+  position: absolute;
+  bottom: -30px;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--card-bg);
+  padding: 4px 8px;
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* ローディング状態 */
+body.pull-to-refresh-loading .indicator {
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    transform: translateX(-50%) scale(1.1);
+  }
+}
+
+/* レディ状態 */
+body.pull-to-refresh-ready .iconWrapper {
+  background: var(--primary-color);
+}
+
+body.pull-to-refresh-ready .iconWrapper svg {
+  color: white;
+}
+
+/* ダークモード対応 */
+:root[data-theme="dark"] .iconWrapper {
+  background: var(--card-bg-dark, #2a2a2a);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+:root[data-theme="darkblue"] .iconWrapper {
+  background: var(--card-bg-darkblue, #1a2e46);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}

--- a/components/pull-to-refresh-indicator.tsx
+++ b/components/pull-to-refresh-indicator.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+import styles from './pull-to-refresh-indicator.module.css'
+
+interface PullToRefreshIndicatorProps {
+  isPulling: boolean
+  pullDistance: number
+}
+
+export function PullToRefreshIndicator({ isPulling, pullDistance }: PullToRefreshIndicatorProps) {
+  if (!isPulling) return null
+  
+  const progress = Math.min(pullDistance / 80, 1)
+  const rotation = progress * 180
+  const opacity = Math.min(progress, 0.8)
+  
+  return (
+    <div 
+      className={styles.indicator}
+      style={{
+        transform: `translateY(${pullDistance}px)`,
+        opacity
+      }}
+    >
+      <div className={styles.iconWrapper}>
+        <RefreshCw 
+          size={24}
+          style={{
+            transform: `rotate(${rotation}deg)`,
+            transition: 'transform 0.2s ease'
+          }}
+        />
+        {progress >= 1 && (
+          <span className={styles.text}>離して更新</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/reload-button.module.css
+++ b/components/reload-button.module.css
@@ -1,0 +1,85 @@
+.reloadButton {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: white;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.reloadButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.35);
+  transform: scale(1.05);
+}
+
+.reloadButton:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.reloadButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.reloadButton svg {
+  transition: transform 0.2s ease;
+}
+
+.reloadButton:hover:not(:disabled) svg {
+  transform: rotate(90deg);
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.tooltip {
+  position: absolute;
+  bottom: -35px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--tooltip-bg, rgba(0, 0, 0, 0.8));
+  color: var(--tooltip-text, white);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.reloadButton:hover .tooltip {
+  opacity: 1;
+}
+
+/* モバイル対応 */
+@media (max-width: 640px) {
+  .reloadButton {
+    width: 36px;
+    height: 36px;
+  }
+  
+  .reloadButton svg {
+    width: 18px;
+    height: 18px;
+  }
+  
+  .tooltip {
+    display: none;
+  }
+}

--- a/components/reload-button.tsx
+++ b/components/reload-button.tsx
@@ -2,11 +2,20 @@
 
 import { RefreshCw } from 'lucide-react'
 import { isPWA } from '@/lib/pwa-utils'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import styles from './reload-button.module.css'
 
 export function ReloadButton() {
   const [isReloading, setIsReloading] = useState(false)
+  const [isDebugMode, setIsDebugMode] = useState(false)
+  
+  useEffect(() => {
+    // URLパラメータでデバッグモードをチェック
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search)
+      setIsDebugMode(params.get('debug-pwa') === 'true')
+    }
+  }, [])
 
   const handleReload = async () => {
     setIsReloading(true)
@@ -29,8 +38,8 @@ export function ReloadButton() {
     }, 500)
   }
 
-  // PWA環境でのみ表示
-  if (!isPWA()) return null
+  // PWA環境またはデバッグモードでのみ表示
+  if (!isPWA() && !isDebugMode) return null
 
   return (
     <button

--- a/components/reload-button.tsx
+++ b/components/reload-button.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+import { isPWA } from '@/lib/pwa-utils'
+import { useState } from 'react'
+import styles from './reload-button.module.css'
+
+export function ReloadButton() {
+  const [isReloading, setIsReloading] = useState(false)
+
+  const handleReload = async () => {
+    setIsReloading(true)
+    
+    // Service Workerのキャッシュをクリア
+    if ('caches' in window) {
+      try {
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames.map(name => caches.delete(name))
+        )
+      } catch (error) {
+        console.error('Failed to clear caches:', error)
+      }
+    }
+    
+    // 少し待ってからリロード（アニメーション表示のため）
+    setTimeout(() => {
+      window.location.reload()
+    }, 500)
+  }
+
+  // PWA環境でのみ表示
+  if (!isPWA()) return null
+
+  return (
+    <button
+      onClick={handleReload}
+      disabled={isReloading}
+      className={styles.reloadButton}
+      aria-label="ページをリロード"
+      title="ページをリロード (Ctrl+R)"
+    >
+      <RefreshCw 
+        size={20} 
+        className={isReloading ? styles.spinning : ''} 
+      />
+      <span className={styles.tooltip}>リロード</span>
+    </button>
+  )
+}

--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function useKeyboardShortcuts() {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ctrl/Cmd + R でリロード
+      if ((e.ctrlKey || e.metaKey) && e.key === 'r') {
+        e.preventDefault()
+        
+        // キャッシュクリアしてリロード
+        const performReload = () => {
+          if (typeof window !== 'undefined' && window.location) {
+            window.location.reload()
+          }
+        }
+        
+        if ('caches' in window) {
+          caches.keys().then(names => {
+            Promise.all(names.map((name: string) => caches.delete(name)))
+              .then(() => {
+                performReload()
+              })
+          })
+        } else {
+          performReload()
+        }
+      }
+      
+      // F5キーでリロード
+      if (e.key === 'F5') {
+        e.preventDefault()
+        if (typeof window !== 'undefined' && window.location) {
+          window.location.reload()
+        }
+      }
+    }
+
+    // イベントリスナー登録
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [])
+}

--- a/hooks/use-pull-to-refresh.ts
+++ b/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,96 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { isPWA } from '@/lib/pwa-utils'
+
+export function usePullToRefresh() {
+  const [isPulling, setIsPulling] = useState(false)
+  const [pullDistance, setPullDistance] = useState(0)
+
+  useEffect(() => {
+    // PWA環境でのみ有効
+    if (!isPWA()) return
+
+    let startY = 0
+    let currentY = 0
+    let isActive = false
+
+    const handleTouchStart = (e: TouchEvent) => {
+      // ページ最上部でのみ開始
+      if (window.scrollY === 0) {
+        startY = e.touches[0].pageY
+        isActive = true
+      }
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!isActive) return
+      
+      currentY = e.touches[0].pageY
+      const distance = currentY - startY
+      
+      // 下方向へのスワイプのみ処理
+      if (distance > 0) {
+        // 最大150pxまで
+        const limitedDistance = Math.min(distance, 150)
+        setPullDistance(limitedDistance)
+        setIsPulling(true)
+        
+        // プルダウンインジケーターを表示
+        if (limitedDistance > 80) {
+          document.body.classList.add('pull-to-refresh-ready')
+        } else {
+          document.body.classList.remove('pull-to-refresh-ready')
+        }
+        
+        // スクロールを防止
+        if (distance > 10) {
+          e.preventDefault()
+        }
+      }
+    }
+
+    const handleTouchEnd = () => {
+      if (isActive && pullDistance > 80) {
+        // リロード実行
+        document.body.classList.add('pull-to-refresh-loading')
+        
+        // キャッシュクリアとリロード
+        if ('caches' in window) {
+          caches.keys().then(names => {
+            Promise.all(names.map(name => caches.delete(name)))
+              .then(() => {
+                setTimeout(() => {
+                  window.location.reload()
+                }, 500)
+              })
+          })
+        } else {
+          setTimeout(() => {
+            window.location.reload()
+          }, 500)
+        }
+      }
+      
+      // リセット
+      isActive = false
+      setIsPulling(false)
+      setPullDistance(0)
+      document.body.classList.remove('pull-to-refresh-ready')
+    }
+
+    // イベントリスナー登録
+    document.addEventListener('touchstart', handleTouchStart, { passive: true })
+    document.addEventListener('touchmove', handleTouchMove, { passive: false })
+    document.addEventListener('touchend', handleTouchEnd, { passive: true })
+
+    return () => {
+      document.removeEventListener('touchstart', handleTouchStart)
+      document.removeEventListener('touchmove', handleTouchMove)
+      document.removeEventListener('touchend', handleTouchEnd)
+      document.body.classList.remove('pull-to-refresh-ready', 'pull-to-refresh-loading')
+    }
+  }, [pullDistance])
+
+  return { isPulling, pullDistance }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vercel/speed-insights": "^1.2.0",
         "fast-xml-parser": "^4.5.3",
         "idb": "^8.0.3",
+        "lucide-react": "^0.540.0",
         "next": "15.3.3",
         "next-pwa": "^5.6.0",
         "pako": "^2.1.0",
@@ -11409,6 +11410,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.540.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
+      "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "fast-xml-parser": "^4.5.3",
     "idb": "^8.0.3",
+    "lucide-react": "^0.540.0",
     "next": "15.3.3",
     "next-pwa": "^5.6.0",
     "pako": "^2.1.0",


### PR DESCRIPTION
## 概要
PWA環境でリロード機能が使えない問題を解決するため、専用のリロード機能を実装しました。

## 実装内容
### 1. リロードボタン
- ヘッダー右上に回転矢印アイコンのボタンを追加
- PWA環境でのみ表示（通常のブラウザでは非表示）
- Service Workerのキャッシュをクリアしてからリロード

### 2. Pull-to-Refresh（モバイル対応）
- 画面上部を下にスワイプしてリロード
- 80px以上引っ張るとリロード発動
- 視覚的フィードバックインジケーター付き

### 3. キーボードショートカット
- `Ctrl+R` / `Cmd+R`：キャッシュクリア付きリロード  
- `F5`：通常のリロード
- PWA環境で標準のブラウザショートカットを上書き

### 4. デバッグモード
- URLパラメータ `?debug-pwa=true` で通常のブラウザでも動作確認可能
- Vercelプレビューデプロイでのテストに活用

## テスト結果
✅ TypeScript型チェック: エラーなし
✅ ESLint: 新規エラーなし（既存のwarningのみ）
✅ ビルド: 成功
✅ デバッグモードでの動作確認: 正常

## スクリーンショット
- デスクトップビュー（リロードボタン表示）
- モバイルビュー（Pull-to-Refresh対応）

Closes #PWA-RELOAD-ISSUE