### PR TITLE
fix(pwa): force fresh ranking cache

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -315,8 +315,9 @@ const withBundleAnalyzer = bundleAnalyzer({
 const pwaConfig = withPWA({
   dest: 'public',
   register: true,
-  skipWaiting: false,    // ユーザーがページを閉じるまで待機
-  clientsClaim: false,   // 新しいページのみ新しいSWが制御
+  // 新しいSWを即時適用し、古いキャッシュを握らせない
+  skipWaiting: true,
+  clientsClaim: true,
   disable: process.env.NODE_ENV === 'development' && process.env.ENABLE_PWA !== 'true',
   fallbacks: {
     document: '/offline.html'
@@ -330,13 +331,14 @@ const pwaConfig = withPWA({
     // API routes - StaleWhileRevalidate for ranking data
     {
       urlPattern: /^\/api\/ranking/i,
-      handler: 'StaleWhileRevalidate',
+      handler: 'NetworkFirst',
       options: {
-        cacheName: 'ranking-api',
+        cacheName: 'ranking-api-v2',
         expiration: {
           maxEntries: 100,
-          maxAgeSeconds: 20 * 60 // 20 minutes
-        }
+          maxAgeSeconds: 10 * 60 // 10 minutes: staleデータ滞留を短縮
+        },
+        networkTimeoutSeconds: 8
       }
     },
     // External API (Niconico)


### PR DESCRIPTION
## Summary
- make service worker take over immediately (skipWaiting + clientsClaim) to avoid stale SW lingering in PWA/browser installs
- switch /api/ranking runtime cache to NetworkFirst with a new cache name (ranking-api-v2) and shorter maxAge to ensure fresh data

## Testing
- not run (config-only change; needs deploy to verify SW behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Accelerated app update deployment process for faster access to new features
  * Optimized API caching to prioritize live data over cached versions
  * Reduced stale data retention window from 20 to 10 minutes
  * Added network timeout safeguard for more reliable performance during connectivity issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->