### PR TITLE
fix(pwa): disable sw caching for ranking api

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -322,6 +322,12 @@ const pwaConfig = withPWA({
   workboxOptions: {
     disablePrecacheFallback: true
   },
+  // オフラインフォールバックを無効化（Build時のprecacheFallback参照を防ぐ）
+  fallbacks: {
+    document: null,
+    data: null,
+    image: null
+  },
   disable: process.env.NODE_ENV === 'development' && process.env.ENABLE_PWA !== 'true',
   // offline.html を precache しない（Workbox v7 の precacheFallback 問題を回避）
   buildExcludes: [/app-build-manifest\.json$/, /offline\.html$/],


### PR DESCRIPTION
## Summary
- switch /api/ranking runtimeCaching to NetworkOnly so service worker never serves stale ranking responses
- relies on prior skipWaiting/clientsClaim so new SW takes over immediately

## Testing
- not run (config-only; verify in preview that reloads/genre+tag switches always pull fresh data)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ranking data now always fetched from the network to ensure up-to-date results and avoid serving stale cached data.

* **Chores**
  * PWA precache fallback disabled for compatibility, adjusting offline/fallback behavior for the app’s resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->