### PR TITLE
fix: force-remove legacy sw caches

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -35,6 +35,7 @@ import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts'
 import { PullToRefreshIndicator } from '@/components/pull-to-refresh-indicator'
 import { TimeRangeFilter, filterByTimeRange, type TimeRangeValue } from '@/components/time-range-filter'
 import { ScrollToTopButton } from '@/components/scroll-to-top-button'
+import { ServiceWorkerClearer } from '@/components/sw-cache-clearer'
 import './client-page.css'
 import '@/components/ranking-item-responsive.css'
 
@@ -1213,6 +1214,7 @@ export default function ClientPage({
   try {
     return (
       <TagDisplayProvider>
+        <ServiceWorkerClearer />
         <PullToRefreshIndicator isPulling={isPulling} pullDistance={pullDistance} />
         <div className="selectors-container">
         <RankingSelector 

--- a/components/sw-cache-clearer.tsx
+++ b/components/sw-cache-clearer.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect } from 'react'
+
+// 古い next-pwa / Workbox サービスワーカーと Cache Storage を強制的に掃除する
+// 既存ユーザー環境で stale データが残るのを防ぐため、1 セッション 1 回だけ実行する
+export function ServiceWorkerClearer() {
+  useEffect(() => {
+    const flagKey = 'nr-sw-clear-done'
+    if (typeof window === 'undefined') return
+    if (sessionStorage.getItem(flagKey)) return
+
+    const unregister = async () => {
+      try {
+        if ('serviceWorker' in navigator) {
+          const regs = await navigator.serviceWorker.getRegistrations()
+          await Promise.all(regs.map((reg) => reg.unregister()))
+        }
+      } catch (error) {
+        console.warn('[ServiceWorkerClearer] unregister failed', error)
+      }
+    }
+
+    const clearCaches = async () => {
+      try {
+        if (typeof caches !== 'undefined') {
+          const keys = await caches.keys()
+          // Workbox/next-pwa が生成したキャッシュは全削除
+          await Promise.all(keys.map((key) => caches.delete(key)))
+        }
+      } catch (error) {
+        console.warn('[ServiceWorkerClearer] cache cleanup failed', error)
+      }
+    }
+
+    unregister().finally(clearCaches).finally(() => {
+      sessionStorage.setItem(flagKey, '1')
+    })
+  }, [])
+
+  return null
+}
+


### PR DESCRIPTION
- add runtime cleaner that unregisters old service workers and wipes Cache Storage once per session\n- should eliminate stale ranking data fetched by legacy workbox caches even after PWA removal\n- no UI change; runs immediately on client page mount\n\n検証:\n- npm run build 実行済み (既存の lint warning のみ)\n\n次の確認:\n- Vercel preview で stale データが出ないか (reload でも最新になるか)\n- 既存クライアントで stale が出る場合はブラウザキャッシュを手動クリアして比較

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic clearing of old service workers and cached data occurs on the first app load of each session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->