### PR TITLE
fix: fetch ranking with no-store to avoid stale prod cache

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,8 @@ import type { RankingGenre, RankingPeriod } from '@/types/ranking-config'
 import { RANKING_GENRES } from '@/types/ranking-config'
 import { notFound } from 'next/navigation'
 import { CACHE_DURATIONS } from '@/lib/cache-durations'
-// ISRを使用してFunction Invocationsを削減
-export const revalidate = 1200 // 20分間キャッシュ（鮮度重視）
+// 完全動的レンダリング（Data Cache も無効化して毎回最新を取得）
+export const revalidate = 0
 
 // Dynamic imports for better code splitting
 export const dynamic = 'force-dynamic'
@@ -140,7 +140,7 @@ async function fetchRankingData(genre: string = 'all', period: string = '24h', t
     }
     
     const response = await fetch(apiUrl, {
-      next: { revalidate: 1200 },
+      cache: 'no-store',
       headers
     })
     


### PR DESCRIPTION
- app/page.tsx の SSR fetch を  に変更し、Data Cache / ISR 経由の古いランキングを回避\n- ページの  を 0 にして完全動的化（旧キャッシュを拾わない）\n\n背景:\n- プレビューでは最新だが本番だけ 2週間前の JSON が初期描画で返る -> Vercel Data Cache が古いレスポンスを保持し続け、revalidate が効かない挙動と整合\n- クライアント側で period 切替すると最新になるので、API 自体は最新。SSR 初期データのみが stale という症状に対処\n\n検証:\n- npm run build 通過（既存の lint warning のみ）\n\n期待効果:\n- 本番でリロードしても毎回 API へ直撃し、初期描画が最新データになる（マネ×拓… が 1 位に固定される事象を解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data fetching behavior to prioritize real-time content freshness by disabling caching mechanisms and ensuring the latest data is always retrieved. Note: This may impact page load performance due to increased server requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->