### PR TITLE
fix: avoid empty SSR ranking by cache-bust retry

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,36 +139,47 @@ async function fetchRankingData(genre: string = 'all', period: string = '24h', t
       headers['X-SSR-Request'] = 'true'
     }
     
-    const response = await fetch(apiUrl, {
+    const doFetch = async (url: string, options?: RequestInit) => {
+      const res = await fetch(url, options)
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      let json: any
+      try {
+        json = await res.clone().json()
+      } catch {
+        const text = await res.text()
+        json = JSON.parse(text)
+      }
+      return json
+    }
+
+    // 1st: 通常キャッシュ経路
+    const primaryJson = await doFetch(apiUrl, {
       next: { revalidate: 1200 },
       headers
     })
-    
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-    }
-    
-    // レスポンスをテキストとして取得してJSONパース
-    // Content-Encodingヘッダーの問題を回避
-    let data: any
-    try {
-      // まずJSONとして直接パースを試みる
-      data = await response.json()
-    } catch (jsonError) {
-      // JSONパースに失敗した場合、テキストとして取得して再度パース
-      const text = await response.text()
-      try {
-        data = JSON.parse(text)
-      } catch (parseError) {
-        throw new Error('Invalid JSON response from API')
-      }
-    }
-    
-    if (data && data.items && Array.isArray(data.items)) {
-      // NGフィルタリングを適用
+
+    const buildResult = async (data: any) => {
+      if (!data || !Array.isArray(data.items)) throw new Error('Invalid data structure: missing items array')
       const { filteredData } = await filterRankingDataServer(data)
       return filteredData
     }
+
+    const primaryResult = await buildResult(primaryJson)
+
+    // 空配列だった場合のみ cache-bust 再取得（偶発的な空キャッシュを避ける）
+    if (primaryResult.items.length === 0) {
+      const cacheBustUrl = `${apiUrl}&_cb=${Date.now()}`
+      const freshJson = await doFetch(cacheBustUrl, {
+        cache: 'no-store',
+        headers: {
+          ...headers,
+          'Cache-Control': 'no-cache'
+        }
+      })
+      return await buildResult(freshJson)
+    }
+
+    return primaryResult
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('[SSR] API error:', error instanceof Error ? error.message : String(error))


### PR DESCRIPTION
- SSR のランキング取得で items が空だった場合に限り、 +  付きで再取得するようにして、偶発的な空キャッシュ配信を防止\n- 通常はこれまで通り  を使い、不要な負荷は避ける\n- NGフィルタを通した結果でも空なら再取得するため、SSR初期表示での "ランキングデータがありません" を避ける目的\n\n検証:\n- npm run build 通過（既存の lint warning のみ）\n\n狙い:\n- 本番のみ再現する「リロード直後だけ古い/空データ」症状を抑止し、常に API の最新を取りに行くフォールバックを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and response validation to ensure data request reliability.
  * Implemented automatic cache-busting retry mechanism when the initial fetch returns empty results, improving data availability.

* **Refactor**
  * Consolidated data fetching operations and centralized error handling logic to reduce code duplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->