### PR TITLE
fix: force re-fetch when SSR ranking data is empty

### DIFF
--- a/__tests__/unit/app/initial-load-guard.test.ts
+++ b/__tests__/unit/app/initial-load-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { shouldSkipInitialFetch } from '@/app/client-page'
+
+const baseConfig = {
+  genre: 'all',
+  period: '24h',
+  tag: undefined,
+} as const
+
+describe('shouldSkipInitialFetch', () => {
+  it('returns true only when initial load, no force, and config matches initial', () => {
+    const result = shouldSkipInitialFetch(true, false, baseConfig, 'all', '24h', undefined)
+    expect(result).toBe(true)
+  })
+
+  it('returns false when force is true even if config matches', () => {
+    const result = shouldSkipInitialFetch(true, true, baseConfig, 'all', '24h', undefined)
+    expect(result).toBe(false)
+  })
+
+  it('returns false when config differs', () => {
+    const result = shouldSkipInitialFetch(true, false, { ...baseConfig, period: 'hour' }, 'all', '24h', undefined)
+    expect(result).toBe(false)
+  })
+
+  it('returns false after initial load has completed', () => {
+    const result = shouldSkipInitialFetch(false, false, baseConfig, 'all', '24h', undefined)
+    expect(result).toBe(false)
+  })
+})

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -59,6 +59,23 @@ const isPWA = () => {
          document.referrer.includes('android-app://') // Androidの場合
 }
 
+export function shouldSkipInitialFetch(
+  isInitialLoad: boolean,
+  force: boolean,
+  cfg: RankingConfig,
+  initialGenre: string,
+  initialPeriod: string,
+  initialTag?: string,
+) {
+  if (!isInitialLoad) return false
+  if (force) return false
+  return (
+    cfg.genre === initialGenre &&
+    cfg.period === initialPeriod &&
+    cfg.tag === initialTag
+  )
+}
+
 // タグ表示トグルボタンコンポーネント
 function TagToggleButton() {
   const { showTags, toggleTags } = useTagDisplay()
@@ -495,6 +512,7 @@ export default function ClientPage({
     
     // 初回ロードの処理
     if (isInitialLoad) {
+      const initialMatch = shouldSkipInitialFetch(isInitialLoad, force, newConfig, initialGenre, initialPeriod, initialTag)
       // カスタムランキングの場合は必ずデータフェッチを実行
       if (newConfig.genre === 'custom') {
         // IndexedDBの読み込みが完了するまで待機
@@ -514,9 +532,7 @@ export default function ClientPage({
         })
         setIsInitialLoad(false)
         // データフェッチに続行
-      } else if (newConfig.genre === initialGenre && 
-                 newConfig.period === initialPeriod && 
-                 newConfig.tag === initialTag) {
+      } else if (initialMatch) {
         // 通常のジャンルで同じ設定の場合はSSRデータを使用
         serverLog.info('Initial load - using SSR data, skipping API fetch', {
           initialGenre,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initial load logic organization through centralized comparison utility
* **Tests**
  * Added comprehensive unit tests for initial fetch behavior validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->