### PR TITLE
perf: extend /api/ranking edge cache to 10 minutes

### DIFF
--- a/app/api/ranking/route.ts
+++ b/app/api/ranking/route.ts
@@ -85,8 +85,8 @@ export async function GET(request: NextRequest) {
       responseHeaders.set('content-type', 'application/json')
       
       // キャッシュ禁止（ブラウザ・CDN・Vercel Edge）
-      // 短期エッジキャッシュ + SWR で鮮度と性能を両立
-      const sMaxage = 60
+      // 短期エッジキャッシュ + SWR で鮮度と性能を両立（10分）
+      const sMaxage = 600
       const swr = 540
       responseHeaders.set('cache-control', `public, max-age=0, s-maxage=${sMaxage}, stale-while-revalidate=${swr}`)
       responseHeaders.set('cdn-cache-control', `public, s-maxage=${sMaxage}`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching efficiency for ranking data, resulting in improved performance and faster load times when accessing ranking information during repeated requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->