### PR TITLE
fix: CDNキャッシュによる古いデータ表示問題を完全修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,9 +13,10 @@ import type { RankingGenre, RankingPeriod } from '@/types/ranking-config'
 import { RANKING_GENRES } from '@/types/ranking-config'
 import { notFound } from 'next/navigation'
 import { CACHE_DURATIONS } from '@/lib/cache-durations'
-// 旧ISRキャッシュが古データを返していたため完全動的に変更
-// → キャッシュ戦略を見直し、短期ISRで性能と鮮度を両立
-export const revalidate = 60
+// 動的レンダリング強制: CDNキャッシュが古いデータを返す問題を防ぐ
+// キャッシュは Cloudflare Workers 側で管理し、Vercel側は常に最新データを取得
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 // Browser recommendation component is temporarily disabled due to missing lucide-react dependency
 
@@ -159,9 +160,9 @@ async function fetchRankingData(genre: string = 'all', period: string = '24h', t
       return filteredData
     }
 
-    // 1st: キャッシュを活かしつつ短周期で再検証
+    // キャッシュなし: 常に最新データを取得（古いデータ問題の根本対策）
     const { json: primaryJson, meta: primaryMeta } = await doFetch(apiUrl, {
-      next: { revalidate: 60 },
+      cache: 'no-store',
       headers
     })
     const primaryResult = await buildResult(primaryJson, primaryMeta)

--- a/middleware.ts
+++ b/middleware.ts
@@ -201,21 +201,20 @@ const noStorePaths: string[] = []
   }
   
   // APIルートの最適化
-  // API /ranking と ルートHTML は no-store を強制（動的レンダリングと整合）
-  // /api/ranking は鮮度優先だが、負荷対策で短いCDNキャッシュを許可（15分）
+  // /api/ranking: no-store を強制（古いデータ問題の根本原因だったため）
+  // CDNキャッシュは Cloudflare Workers 側で管理するため、Vercel側はキャッシュしない
   if (request.nextUrl.pathname.startsWith('/api/ranking')) {
-    const smax = 900
-    response.headers.set('Cache-Control', `public, max-age=0, s-maxage=${smax}, stale-while-revalidate=${smax}`)
-    response.headers.set('CDN-Cache-Control', `public, s-maxage=${smax}`)
-    response.headers.set('Vercel-CDN-Cache-Control', `public, s-maxage=${smax}`)
+    response.headers.set('Cache-Control', 'no-store, must-revalidate')
+    response.headers.set('CDN-Cache-Control', 'no-store')
+    response.headers.set('Vercel-CDN-Cache-Control', 'no-store')
   }
 
-  // ルートHTMLは短期キャッシュ（5分）で性能と鮮度を両立
+  // ルートHTML: no-store を強制（BFCache/PWA復帰時の古いデータ問題を防ぐ）
+  // SSRは毎回実行し、最新データを取得する
   if (request.nextUrl.pathname === '/' || request.nextUrl.pathname === '') {
-    const smax = 300
-    response.headers.set('Cache-Control', `public, max-age=0, s-maxage=${smax}, stale-while-revalidate=${smax}`)
-    response.headers.set('CDN-Cache-Control', `public, s-maxage=${smax}`)
-    response.headers.set('Vercel-CDN-Cache-Control', `public, s-maxage=${smax}`)
+    response.headers.set('Cache-Control', 'no-store, must-revalidate')
+    response.headers.set('CDN-Cache-Control', 'no-store')
+    response.headers.set('Vercel-CDN-Cache-Control', 'no-store')
   }
   
   // 静的アセットの長期キャッシュ設定


### PR DESCRIPTION
## Summary
- リロード時に2日前のランキングデータが表示される問題を修正
- Vercel CDN キャッシュを無効化し、常に最新データを取得するよう変更

## 根本原因
`middleware.ts` で設定されていた CDN キャッシュ設定が問題の原因でした：
- `/api/ranking`: 15分キャッシュ (`s-maxage=900`)
- ルートHTML (`/`): 5分キャッシュ (`s-maxage=300`)

`stale-while-revalidate` の設定により、再検証が失敗すると古いキャッシュが残り続け、2日前のデータが表示される状態になっていました。

## 修正内容

### 1. middleware.ts
| 変更前 | 変更後 |
|--------|--------|
| `/api/ranking`: `s-maxage=900` (15分) | `no-store` |
| ルートHTML: `s-maxage=300` (5分) | `no-store` |

### 2. app/page.tsx
| 変更前 | 変更後 |
|--------|--------|
| `export const revalidate = 60` | `export const dynamic = 'force-dynamic'` |
| `next: { revalidate: 60 }` | `cache: 'no-store'` |

## キャッシュ戦略の方針変更
- **Vercel側**: キャッシュなし（常に最新データ取得）
- **Cloudflare Workers側**: 必要に応じてエッジキャッシュを管理

## Test plan
- [ ] ブラウザでリロードして最新のランキングデータが表示されることを確認
- [ ] PWAでリロードボタンを押して最新データが表示されることを確認
- [ ] モバイルでブックマークからアクセスして最新データが表示されることを確認
- [ ] レスポンスヘッダーに `Cache-Control: no-store` が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Real-Time Updates**
  * Switched to real-time data fetching across all pages and APIs to replace previous caching strategies
  * All rankings and content now refresh on every request, guaranteeing you always see the latest information
  * Removed caching to deliver fresh data instantly without potential stale content

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->