### PR TITLE
fix: ensure fresh data on page reload

### DIFF
--- a/app/api/ranking/route.ts
+++ b/app/api/ranking/route.ts
@@ -84,10 +84,10 @@ export async function GET(request: NextRequest) {
       // Content-Type
       responseHeaders.set('content-type', 'application/json')
       
-      // キャッシュ禁止（ブラウザ・CDN・Vercel Edge）
-      // 短期エッジキャッシュ + SWR で鮮度と性能を両立（10分）
-      const sMaxage = 600
-      const swr = 540
+      // キャッシュを短縮（5分）して、より頻繁に新しいデータを取得
+      // ただし、完全に無効にするとパフォーマンスに影響するため、SWRで対応
+      const sMaxage = 300 // 5分
+      const swr = 60 // 1分のSWR
       responseHeaders.set('cache-control', `public, max-age=0, s-maxage=${sMaxage}, stale-while-revalidate=${swr}`)
       responseHeaders.set('cdn-cache-control', `public, s-maxage=${sMaxage}`)
       responseHeaders.set('vercel-cdn-cache-control', `public, s-maxage=${sMaxage}`)

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -156,10 +156,19 @@ export default function ClientPage({
   const hasCleanedCacheRef = useRef(false)
   if (!hasCleanedCacheRef.current) {
     hasCleanedCacheRef.current = true
-    if (detectPageReload()) {
-      // リロード時はSSRの最新データを使用するためキャッシュをクリア
+
+    // リロード検出
+    const isReload = detectPageReload()
+
+    // 初回ロード時も含めて、SSRデータが存在する場合はキャッシュをクリア
+    // これにより、常にSSRから渡された最新データが優先される
+    if (isReload || (initialData.items && initialData.items.length > 0)) {
       rankingCache.clear()
-      serverLog.info('Page reload detected - cleared ranking cache before any useEffect runs')
+      serverLog.info('Cache cleared on page load', {
+        isReload,
+        hasSSRData: initialData.items?.length > 0,
+        ssrItemCount: initialData.items?.length || 0
+      })
     }
   }
   


### PR DESCRIPTION
## Summary
- Fix stale ranking data appearing on page reload
- Clear client-side cache when SSR data is available
- Reduce edge cache TTL for fresher data

## Changes
1. **client-page.tsx**: Clear `rankingCache` on initial load when SSR data is present
2. **api/ranking/route.ts**: Reduce edge cache TTL from 10 min to 5 min, SWR from 9 min to 1 min

## Test plan
- [ ] Hard refresh the page and verify latest ranking data is displayed
- [ ] Check browser network tab for proper cache headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized cache handling for improved data freshness and performance across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->