### PR TITLE
feat: add scheduled redeploy to fix stale ranking data

### DIFF
--- a/.deploy-timestamp
+++ b/.deploy-timestamp
@@ -1,0 +1,2 @@
+Last scheduled redeploy: Initial
+Reason: Initial setup

--- a/.github/workflows/scheduled-redeploy.yml
+++ b/.github/workflows/scheduled-redeploy.yml
@@ -1,0 +1,67 @@
+name: Scheduled Redeploy
+
+# 定期的にVercelを再デプロイしてキャッシュの古いデータ問題を解決
+# Vercelのビルドキャッシュが原因でリロード時に古いランキングデータが表示される問題の回避策
+
+on:
+  schedule:
+    # 毎日 JST 6:00, 12:00, 18:00, 24:00 (UTC 21:00, 03:00, 09:00, 15:00)
+    - cron: '0 21,3,9,15 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual redeploy'
+        required: false
+        default: 'Manual trigger'
+
+concurrency:
+  group: scheduled-redeploy
+  cancel-in-progress: true
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SECRETS_ADMIN_PAT }}
+          fetch-depth: 0
+
+      - name: Update deploy timestamp
+        env:
+          DEPLOY_REASON: ${{ github.event.inputs.reason || 'Scheduled' }}
+        run: |
+          # タイムスタンプファイルを更新（これだけでVercelが再デプロイをトリガー）
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "Last scheduled redeploy: $TIMESTAMP" > .deploy-timestamp
+          echo "Reason: $DEPLOY_REASON" >> .deploy-timestamp
+
+      - name: Commit and push
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_REASON: ${{ github.event.inputs.reason || 'Scheduled cron job' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .deploy-timestamp
+
+          # 変更がある場合のみコミット
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            git commit -m "chore: scheduled redeploy at $TIMESTAMP
+
+Automated redeploy to refresh Vercel build cache and ensure fresh ranking data.
+
+Trigger: $EVENT_NAME
+Reason: $DEPLOY_REASON"
+
+            git push origin main
+            echo "Successfully pushed redeploy commit"
+          fi


### PR DESCRIPTION
## Summary
- Add scheduled workflow to trigger Vercel redeploy every 6 hours
- Fixes issue where page reload shows stale ranking data from previous deploy

## Problem
When the page is reloaded, ranking data from the time of the last deploy is displayed instead of the latest data. This is caused by Vercel's build cache.

## Solution
- Scheduled workflow runs 4 times daily (JST 6:00, 12:00, 18:00, 24:00)
- Updates `.deploy-timestamp` file which triggers Vercel to redeploy
- Can also be triggered manually via `workflow_dispatch`

## Test plan
- [ ] Manually trigger the workflow via GitHub Actions
- [ ] Verify Vercel redeploy is triggered
- [ ] Confirm fresh ranking data after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment infrastructure with automated scheduled redeploys to maintain optimal performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->