### PR TITLE
fix(cache): remove ISR cache causing stale ranking data

### DIFF
--- a/app/api/ranking/route.ts
+++ b/app/api/ranking/route.ts
@@ -52,8 +52,8 @@ export async function GET(request: NextRequest) {
       const response = await fetch(url.toString(), {
         headers,
         signal: controller.signal,
-        // キャッシュ制御
-        next: { revalidate: 1800 }
+        // キャッシュ無効化: ISRキャッシュによる古いデータ問題を防ぐ
+        cache: 'no-store'
       }).finally(() => {
         clearTimeout(timeoutId)
       })

--- a/components/sw-cache-clearer.tsx
+++ b/components/sw-cache-clearer.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react'
 // localStorage にバージョン番号を保存し、バージョンが変わった時に再度クリーンアップを実行
 // これにより、新しい問題が発生した場合にバージョンを上げるだけで全ユーザーに再クリーンアップを適用可能
 
-const CLEANUP_VERSION = '2' // バージョンを上げると全ユーザーで再度クリーンアップが実行される
+const CLEANUP_VERSION = '3' // バージョンを上げると全ユーザーで再度クリーンアップが実行される (2026-01-21: ISRキャッシュ問題対応)
 const FLAG_KEY = 'nr-sw-clear-version'
 
 export function ServiceWorkerClearer() {

--- a/lib/fetch-ranking.ts
+++ b/lib/fetch-ranking.ts
@@ -47,8 +47,8 @@ async function fetchRankingViaGateway(period: RankingPeriod, genre: RankingGenre
     headers: {
       Accept: 'application/json'
     },
-    // SSR からの取得はキャッシュを尊重
-    next: { revalidate: 1800 }
+    // キャッシュ無効化: ISRキャッシュによる古いデータ問題を防ぐ
+    cache: 'no-store'
   })
   if (!response.ok) {
     throw new Error(`API gateway responded with ${response.status}`)


### PR DESCRIPTION
## Summary
- ISRキャッシュ設定(`revalidate: 1800`)を削除し、古いランキングデータが表示される問題を根本的に修正
- Service Workerクリーンアップのバージョンを上げて全ユーザーでキャッシュをクリア

## Problem
ページをリロードすると1週間以上前のランキングデータが表示される問題が発生していました。Vercelのキャッシュ削除で一時的に解消するものの、再発を繰り返していました。

## Root Cause
2つのファイルに残っていた`next: { revalidate: 1800 }`（30分ISRキャッシュ）設定が原因でした：
- `app/api/ranking/route.ts:56`
- `lib/fetch-ranking.ts:51`

これにより、Next.jsの内部キャッシュ（`.next/cache`）に古いデータが保存され続けていました。

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `app/api/ranking/route.ts` | `revalidate: 1800` → `cache: 'no-store'` |
| `lib/fetch-ranking.ts` | `revalidate: 1800` → `cache: 'no-store'` |
| `components/sw-cache-clearer.tsx` | `CLEANUP_VERSION: '2'` → `'3'` |

## Test Plan
- [ ] ローカルで `npm run build && npm run start` でビルド確認
- [ ] Vercelプレビューデプロイ後、`curl -I` でキャッシュヘッダー確認
- [ ] 本番デプロイ後、ページリロードで最新データが表示されることを確認
- [ ] 複数のブラウザでテスト（Chrome, Safari, Firefox）

## Related Issues
- 過去のキャッシュ問題: #100, #116, #118, #119, #120, #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranking data freshness by updating caching mechanisms to serve the latest information immediately.
  * Enhanced cache management to prevent outdated data from being displayed.
  * Updated local cache clearing to ensure users receive the most current ranking data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->