### PR TITLE
fix(scraper): merge tag data into items array for custom ranking filtering

### DIFF
--- a/lib/scraper.ts
+++ b/lib/scraper.ts
@@ -122,18 +122,19 @@ export async function scrapeRankingPageNvApiOnly(
       // 人気タグ集計のため、上位50件のみタグを取得（パフォーマンス最適化）
       const videoIds = items.slice(0, 50).map(item => item.id!).filter(Boolean)
       const tagsMap = await fetchVideoTagsBatch(videoIds, 5) // 並列数を減らして安定性向上
-      
-      // タグ情報をマージ（人気タグ集計用）
-      const itemsWithTags = items.slice(0, 50).map(item => ({
-        ...item,
-        tags: tagsMap.get(item.id!) || []
-      }))
-      
+
+      // タグ情報を元のitems配列にマージ（カスタムランキングフィルタリング用）
+      items.slice(0, 50).forEach(item => {
+        if (item.id) {
+          item.tags = tagsMap.get(item.id) || []
+        }
+      })
+
       // 人気タグを集計
       const tagCounts = new Map<string, number>()
-      itemsWithTags.forEach(item => {
-        item.tags?.forEach(tag => {
-          tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1)
+      items.slice(0, 50).forEach(item => {
+        item.tags?.forEach(tagName => {
+          tagCounts.set(tagName, (tagCounts.get(tagName) || 0) + 1)
         })
       })
       


### PR DESCRIPTION
## Summary

- カスタムランキングでタグベースのフィルタリングが動作しない問題を修正
- nvAPIから取得したタグ情報が`items`配列に反映されていなかったバグを修正

## Root Cause

`lib/scraper.ts`で取得したタグデータが一時変数`itemsWithTags`に保存され、元の`items`配列に戻されていなかった：

```typescript
// 修正前: itemsWithTags はローカル変数で使い捨て
const itemsWithTags = items.slice(0, 50).map(item => ({
  ...item,
  tags: tagsMap.get(item.id!) || []
}))
// itemsWithTags は popularTags 計算のみに使用され、items は変更されない
```

## Fix

`forEach`で元の`items`配列を直接変更するように修正：

```typescript
// 修正後: items 配列を直接変更
items.slice(0, 50).forEach(item => {
  if (item.id) {
    item.tags = tagsMap.get(item.id) || []
  }
})
```

## Test plan

- [ ] `genre=other`などのAPIレスポンスでtagsが空でないことを確認
- [ ] カスタムランキング「真夏の夜の淫夢」などが正しく表示されることを確認
- [ ] 人気タグが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal tag data handling for improved efficiency. The end-user functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->