### PR TITLE
fix(workflow): reduce max-parallel to 1 to avoid API rate limiting

### DIFF
--- a/.github/workflows/update-ranking-parallel.yml
+++ b/.github/workflows/update-ranking-parallel.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         group: [1, 2, 3, 4, 5, 6, 7, 8]
-      max-parallel: 8
+      max-parallel: 1  # Sequential execution to avoid getthumbinfo API rate limiting (HTTP 403)
       fail-fast: false # Continue other groups even if one fails
     
     steps:


### PR DESCRIPTION
## Summary
- **Problem**: Despite PR #180 fixes, 8 groups running in parallel still overwhelms getthumbinfo API
- **Symptom**: Only first genre in each group gets tags (8/23 genres), 92k HTTP 403 errors
- **Solution**: Change max-parallel from 8 to 1 for sequential processing

## Root Cause Analysis
| Metric | Before | After (Expected) |
|--------|--------|------------------|
| Parallel groups | 8 | 1 |
| Concurrent API requests | ~8000 | ~1000 |
| Genres with tags | 8/23 (35%) | 23/23 (100%) |
| Processing time | ~17 min | ~2+ hours |

## Test plan
- [ ] Merge and trigger manual workflow run
- [ ] Verify all 23 genres have tag data after completion
- [ ] Confirm custom rankings work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the ranking update pipeline by adjusting execution flow to prevent rate limiting issues that were causing intermittent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->