### PR TITLE
feat(workflow): implement rotation-based ranking updates to avoid API rate limiting

### DIFF
--- a/.github/workflows/update-ranking-parallel.yml
+++ b/.github/workflows/update-ranking-parallel.yml
@@ -1,113 +1,109 @@
 name: Update Nico Ranking Data (Parallel)
-# Last updated: 2026-01-24 - Rotation-based update to avoid API rate limiting
+# Last updated: 2026-01-24 - KV-group based rotation for simplicity and consistency
 
 on:
   schedule:
-    # 3つのローテーションセットを30分間隔で実行
-    # Set A (Groups 1,2,3): 毎時10分 - all, game, anime, vocaloid, voicesynthesis, entertainment
-    # Set B (Groups 4,5): 毎時30分 - music, sing, dance, play, commentary, cooking
-    # Set C (Groups 6,7,8): 毎時50分 - travel, nature, vehicle, technology, society, mmd, vtuber, radio, sports, animal, other
-    - cron: '10 * * * *'  # Set A
-    - cron: '30 * * * *'  # Set B
-    - cron: '50 * * * *'  # Set C
+    # 3つのKVグループを30分間隔で順番に更新
+    # Set A (KV Group 1): 毎時10分 - all, game, anime, vocaloid, voicesynthesis, entertainment, music, sing
+    # Set B (KV Group 2): 毎時30分 - dance, play, commentary, cooking, travel, nature, vehicle, technology
+    # Set C (KV Group 3): 毎時50分 - society, mmd, vtuber, radio, sports, animal, other
+    - cron: '10 * * * *'  # Set A (KV Group 1)
+    - cron: '30 * * * *'  # Set B (KV Group 2)
+    - cron: '50 * * * *'  # Set C (KV Group 3)
   workflow_dispatch:
     inputs:
-      rotation_set:
-        description: 'Rotation set to run (A, B, C, or ALL for all groups)'
+      kv_group:
+        description: 'KV Group to update (1, 2, 3, or ALL)'
         required: false
         default: 'ALL'
         type: choice
         options:
-          - A
-          - B
-          - C
-          - ALL
+          - '1'
+          - '2'
+          - '3'
+          - 'ALL'
 
 # 同時実行を防ぐ
 concurrency:
   group: update-ranking
   cancel-in-progress: false
 
-env:
-  # ローテーションセットの定義
-  # Set A: Groups 1, 2, 3 (6 genres)
-  # Set B: Groups 4, 5 (6 genres)
-  # Set C: Groups 6, 7, 8 (11 genres)
-  ROTATION_SET_A: "1,2,3"
-  ROTATION_SET_B: "4,5"
-  ROTATION_SET_C: "6,7,8"
-
 jobs:
-  # Step 0: Determine which rotation set to run
-  determine-rotation:
+  # Step 0: Determine which KV group to run
+  determine-kv-group:
     runs-on: ubuntu-latest
     outputs:
-      rotation_set: ${{ steps.calc.outputs.rotation_set }}
-      target_groups: ${{ steps.calc.outputs.target_groups }}
+      kv_group: ${{ steps.calc.outputs.kv_group }}
+      genres: ${{ steps.calc.outputs.genres }}
     steps:
-      - name: Calculate rotation set
+      - name: Calculate KV group
         id: calc
         run: |
+          # KVグループとジャンルのマッピング（GENRE_GROUPSと同じ）
+          KV_GROUP_1_GENRES="all,game,anime,vocaloid,voicesynthesis,entertainment,music,sing"
+          KV_GROUP_2_GENRES="dance,play,commentary,cooking,travel,nature,vehicle,technology"
+          KV_GROUP_3_GENRES="society,mmd,vtuber,radio,sports,animal,other"
+
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # 手動トリガーの場合はinputを使用
-            ROTATION_SET="${{ github.event.inputs.rotation_set }}"
-            if [[ "$ROTATION_SET" == "ALL" ]]; then
-              echo "rotation_set=ALL" >> $GITHUB_OUTPUT
-              echo "target_groups=1,2,3,4,5,6,7,8" >> $GITHUB_OUTPUT
-              echo "Manual trigger: Running ALL groups"
+            KV_GROUP="${{ github.event.inputs.kv_group }}"
+            if [[ "$KV_GROUP" == "ALL" ]]; then
+              echo "kv_group=ALL" >> $GITHUB_OUTPUT
+              echo "genres=$KV_GROUP_1_GENRES,$KV_GROUP_2_GENRES,$KV_GROUP_3_GENRES" >> $GITHUB_OUTPUT
+              echo "Manual trigger: Running ALL KV groups"
             else
-              echo "rotation_set=$ROTATION_SET" >> $GITHUB_OUTPUT
-              case "$ROTATION_SET" in
-                A) echo "target_groups=1,2,3" >> $GITHUB_OUTPUT ;;
-                B) echo "target_groups=4,5" >> $GITHUB_OUTPUT ;;
-                C) echo "target_groups=6,7,8" >> $GITHUB_OUTPUT ;;
+              echo "kv_group=$KV_GROUP" >> $GITHUB_OUTPUT
+              case "$KV_GROUP" in
+                1) echo "genres=$KV_GROUP_1_GENRES" >> $GITHUB_OUTPUT ;;
+                2) echo "genres=$KV_GROUP_2_GENRES" >> $GITHUB_OUTPUT ;;
+                3) echo "genres=$KV_GROUP_3_GENRES" >> $GITHUB_OUTPUT ;;
               esac
-              echo "Manual trigger: Running Set $ROTATION_SET"
+              echo "Manual trigger: Running KV Group $KV_GROUP"
             fi
           else
             # スケジュールトリガーの場合は時刻から判定
             CURRENT_MINUTE=$(date -u '+%M')
             echo "Current UTC minute: $CURRENT_MINUTE"
 
-            # 10分台 → Set A, 30分台 → Set B, 50分台 → Set C
+            # 10分台 → KV Group 1, 30分台 → KV Group 2, 50分台 → KV Group 3
             if [[ "$CURRENT_MINUTE" -ge 5 && "$CURRENT_MINUTE" -le 15 ]]; then
-              echo "rotation_set=A" >> $GITHUB_OUTPUT
-              echo "target_groups=1,2,3" >> $GITHUB_OUTPUT
-              echo "Schedule trigger: Running Set A (Groups 1,2,3)"
+              echo "kv_group=1" >> $GITHUB_OUTPUT
+              echo "genres=$KV_GROUP_1_GENRES" >> $GITHUB_OUTPUT
+              echo "Schedule trigger: Running KV Group 1 (8 genres)"
             elif [[ "$CURRENT_MINUTE" -ge 25 && "$CURRENT_MINUTE" -le 35 ]]; then
-              echo "rotation_set=B" >> $GITHUB_OUTPUT
-              echo "target_groups=4,5" >> $GITHUB_OUTPUT
-              echo "Schedule trigger: Running Set B (Groups 4,5)"
+              echo "kv_group=2" >> $GITHUB_OUTPUT
+              echo "genres=$KV_GROUP_2_GENRES" >> $GITHUB_OUTPUT
+              echo "Schedule trigger: Running KV Group 2 (8 genres)"
             else
-              echo "rotation_set=C" >> $GITHUB_OUTPUT
-              echo "target_groups=6,7,8" >> $GITHUB_OUTPUT
-              echo "Schedule trigger: Running Set C (Groups 6,7,8)"
+              echo "kv_group=3" >> $GITHUB_OUTPUT
+              echo "genres=$KV_GROUP_3_GENRES" >> $GITHUB_OUTPUT
+              echo "Schedule trigger: Running KV Group 3 (7 genres)"
             fi
           fi
 
-  # Step 1: Fetch rankings for target groups
+  # Step 1: Fetch rankings for target KV group
   fetch-rankings:
-    needs: determine-rotation
+    needs: determine-kv-group
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7, 8]
-      max-parallel: 8  # ローテーションにより同時実行グループ数は最大3
+        kv_group: [1, 2, 3]
+      max-parallel: 3
       fail-fast: false
 
     steps:
-    - name: Check if this group should run
+    - name: Check if this KV group should run
       id: should_run
       run: |
-        TARGET_GROUPS="${{ needs.determine-rotation.outputs.target_groups }}"
-        CURRENT_GROUP="${{ matrix.group }}"
+        TARGET_KV_GROUP="${{ needs.determine-kv-group.outputs.kv_group }}"
+        CURRENT_KV_GROUP="${{ matrix.kv_group }}"
 
-        if [[ ",$TARGET_GROUPS," == *",$CURRENT_GROUP,"* ]]; then
+        if [[ "$TARGET_KV_GROUP" == "ALL" || "$TARGET_KV_GROUP" == "$CURRENT_KV_GROUP" ]]; then
           echo "should_run=true" >> $GITHUB_OUTPUT
-          echo "Group $CURRENT_GROUP is in target groups: $TARGET_GROUPS"
+          echo "KV Group $CURRENT_KV_GROUP will run (target: $TARGET_KV_GROUP)"
         else
           echo "should_run=false" >> $GITHUB_OUTPUT
-          echo "Skipping group $CURRENT_GROUP (not in target groups: $TARGET_GROUPS)"
+          echo "Skipping KV Group $CURRENT_KV_GROUP (target: $TARGET_KV_GROUP)"
         fi
 
     - name: Checkout repository
@@ -125,7 +121,7 @@ jobs:
       if: steps.should_run.outputs.should_run == 'true'
       run: npm ci
 
-    - name: Fetch rankings for group ${{ matrix.group }}
+    - name: Fetch rankings for KV Group ${{ matrix.kv_group }}
       if: steps.should_run.outputs.should_run == 'true'
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -137,22 +133,23 @@ jobs:
         TAG_FETCH_GENRES: ''
         TAG_FETCH_FOR_TAG_RANKINGS: ${{ secrets.TAG_FETCH_FOR_TAG_RANKINGS || 'true' }}
       run: |
-        echo "Starting group ${{ matrix.group }} at $(date)"
-        echo "Rotation set: ${{ needs.determine-rotation.outputs.rotation_set }}"
+        echo "Starting KV Group ${{ matrix.kv_group }} at $(date)"
+        echo "Target KV Group: ${{ needs.determine-kv-group.outputs.kv_group }}"
 
         if [ -z "$CLOUDFLARE_KV_NAMESPACE_ID" ]; then
           export CLOUDFLARE_KV_NAMESPACE_ID="$CLOUDFLARE_KV_NAMESPACE_ID_FALLBACK"
           echo "Using fallback KV namespace ID"
         fi
 
-        npx tsx scripts/update-ranking-parallel-v2.ts --group ${{ matrix.group }} 8
+        # Use KV group mode (--kv-group) instead of custom groups
+        npx tsx scripts/update-ranking-parallel-v2.ts --kv-group ${{ matrix.kv_group }}
 
     - name: Upload partial results
       if: steps.should_run.outputs.should_run == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: ranking-data-group-${{ matrix.group }}
-        path: ./tmp/ranking-group-${{ matrix.group }}.json
+        name: ranking-data-kv-group-${{ matrix.kv_group }}
+        path: ./tmp/ranking-kv-group-${{ matrix.kv_group }}.json
         retention-days: 1
         if-no-files-found: error
 
@@ -160,19 +157,19 @@ jobs:
       if: steps.should_run.outputs.should_run == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: ng-derived-group-${{ matrix.group }}
-        path: ./tmp/ng-derived-group-${{ matrix.group }}.json
+        name: ng-derived-kv-group-${{ matrix.kv_group }}
+        path: ./tmp/ng-derived-kv-group-${{ matrix.kv_group }}.json
         retention-days: 1
         if-no-files-found: ignore
 
-    - name: Create placeholder for skipped group
+    - name: Create placeholder for skipped KV group
       if: steps.should_run.outputs.should_run == 'false'
       run: |
-        echo "Group ${{ matrix.group }} skipped in this rotation"
+        echo "KV Group ${{ matrix.kv_group }} skipped in this rotation"
 
   # Step 2: Aggregate results and write to KV
   aggregate-and-write:
-    needs: [determine-rotation, fetch-rankings]
+    needs: [determine-kv-group, fetch-rankings]
     runs-on: ubuntu-latest
     if: always()
 
@@ -196,26 +193,26 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: ./tmp
-        pattern: ranking-data-group-*
+        pattern: ranking-data-kv-group-*
       continue-on-error: true
 
     - name: Download NG derived artifacts (if exists)
       uses: actions/download-artifact@v4
       with:
         path: ./tmp
-        pattern: ng-derived-group-*
+        pattern: ng-derived-kv-group-*
       continue-on-error: true
 
     - name: List downloaded files
       run: |
-        echo "Rotation set: ${{ needs.determine-rotation.outputs.rotation_set }}"
-        echo "Target groups: ${{ needs.determine-rotation.outputs.target_groups }}"
+        echo "KV Group: ${{ needs.determine-kv-group.outputs.kv_group }}"
+        echo "Genres: ${{ needs.determine-kv-group.outputs.genres }}"
         echo ""
         echo "Downloaded artifacts:"
         ls -la ./tmp/ 2>/dev/null || echo "No tmp directory"
         echo ""
         echo "Ranking files:"
-        find ./tmp -name "ranking-group-*.json" 2>/dev/null | sort || echo "No ranking files found"
+        find ./tmp -name "ranking-kv-group-*.json" 2>/dev/null | sort || echo "No ranking files found"
 
     - name: Move files to correct location
       run: |
@@ -228,20 +225,18 @@ jobs:
         echo "Files after moving:"
         ls -la ./tmp/*.json 2>/dev/null || echo "No JSON files found"
 
-    - name: Aggregate and write to KV (partial update)
+    - name: Aggregate and write to KV
       env:
         CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         CLOUDFLARE_KV_NAMESPACE_ID_FALLBACK: "80f4535c379b4e8cb89ce6dbdb7d2dc9"
-        ROTATION_SET: ${{ needs.determine-rotation.outputs.rotation_set }}
-        TARGET_GROUPS: ${{ needs.determine-rotation.outputs.target_groups }}
+        KV_GROUP_MODE: "true"
       run: |
-        echo "Aggregating results for rotation set: $ROTATION_SET"
-        echo "Target groups: $TARGET_GROUPS"
+        echo "Aggregating results for KV Group: ${{ needs.determine-kv-group.outputs.kv_group }}"
 
-        FOUND_FILES=$(ls ./tmp/ranking-group-*.json 2>/dev/null | wc -l)
-        echo "Found $FOUND_FILES group files"
+        FOUND_FILES=$(ls ./tmp/ranking-kv-group-*.json 2>/dev/null | wc -l)
+        echo "Found $FOUND_FILES KV group files"
 
         if [ "$FOUND_FILES" -eq 0 ]; then
           echo "⚠️ No ranking files found, skipping aggregation"
@@ -285,5 +280,5 @@ jobs:
     - name: Report completion
       run: |
         echo "✅ Ranking update completed at $(date)"
-        echo "Rotation set: ${{ needs.determine-rotation.outputs.rotation_set }}"
-        echo "Target groups: ${{ needs.determine-rotation.outputs.target_groups }}"
+        echo "KV Group: ${{ needs.determine-kv-group.outputs.kv_group }}"
+        echo "Genres: ${{ needs.determine-kv-group.outputs.genres }}"

--- a/scripts/aggregate-ranking-results-direct.ts
+++ b/scripts/aggregate-ranking-results-direct.ts
@@ -288,8 +288,12 @@ async function writeToCloudflareKVGroups(rankingData: any): Promise<void> {
 
 async function main() {
   try {
-    console.log('Aggregating ranking results from all groups...');
-    
+    console.log('Aggregating ranking results...');
+
+    // Detect mode: KV group mode (new) or legacy 8-group mode
+    const kvGroupMode = process.env.KV_GROUP_MODE === 'true';
+    console.log(`Mode: ${kvGroupMode ? 'KV Group (3 groups, no merge needed)' : 'Legacy (8 groups, with merge)'}`);
+
     // Read all partial results
     const tmpDir = './tmp';
     let files: string[] = [];
@@ -299,22 +303,29 @@ async function main() {
       console.error('Failed to read tmp directory:', error);
       process.exit(1);
     }
-    
-    const groupFiles = files.filter(f => f.startsWith('ranking-group-') && f.endsWith('.json'));
+
+    // Support both file naming conventions
+    const kvGroupFiles = files.filter(f => f.startsWith('ranking-kv-group-') && f.endsWith('.json'));
+    const legacyGroupFiles = files.filter(f => f.startsWith('ranking-group-') && f.endsWith('.json'));
+    const groupFiles = kvGroupFiles.length > 0 ? kvGroupFiles : legacyGroupFiles;
+
+    console.log(`Found ${kvGroupFiles.length} KV group files, ${legacyGroupFiles.length} legacy group files`);
+    console.log(`Using: ${kvGroupFiles.length > 0 ? 'KV group files' : 'legacy group files'}`);
+
     // Look for NG derived files in both main tmp and subdirectories
     const ngDerivedFiles: string[] = [];
+    // Note: exec() is used here with hardcoded paths only, no user input - safe from injection
     const allNgFiles = await new Promise<string[]>(async (resolve) => {
-      // Dynamic import for Node.js environment only
       const { exec } = await import('child_process');
-      exec('find ./tmp -name "ng-derived-group-*.json" -type f 2>/dev/null || true', (error: any, stdout: string) => {
+      exec('find ./tmp -name "ng-derived-*.json" -type f 2>/dev/null || true', (error: any, stdout: string) => {
         if (error) {
           console.log('No ng-derived files found via find command');
           resolve([]);
           return;
         }
-        const found = stdout.trim().split('\n').filter(f => f && f.includes('ng-derived-group-'));
+        const found = stdout.trim().split('\n').filter(f => f && f.includes('ng-derived-'));
         console.log(`Found ng-derived files via find: ${found.join(', ')}`);
-        resolve(found); // Return full paths for direct use
+        resolve(found);
       });
     });
     ngDerivedFiles.push(...allNgFiles);

--- a/scripts/update-ranking-parallel-v2.ts
+++ b/scripts/update-ranking-parallel-v2.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env npx tsx
 import type { RankingGenre } from '../types/ranking-config'
+import { GENRE_GROUPS } from '../types/ranking-config'
 import type { RankingItem } from '../types/ranking'
 import { kv } from '../lib/simple-kv'
 import { enrichRankingItemsWithTagDetails } from '../lib/tag-fetcher-simple'
@@ -741,8 +742,82 @@ async function main() {
   }
 }
 
-// Check if this is being run for a specific group (for GitHub Actions matrix)
-if (process.argv[2] === '--group') {
+// Check if this is being run for a KV group (GENRE_GROUPS based - recommended)
+if (process.argv[2] === '--kv-group') {
+  const kvGroupId = parseInt(process.argv[3]);
+
+  if (!kvGroupId || kvGroupId < 1 || kvGroupId > 3) {
+    console.error('Invalid KV group ID. Usage: --kv-group <1|2|3>');
+    process.exit(1);
+  }
+
+  // Use GENRE_GROUPS for KV-aligned operation
+  const groupGenres = GENRE_GROUPS[kvGroupId as 1 | 2 | 3].filter(g => g !== 'custom') as RankingGenre[];
+  console.log(`Using KV Group ${kvGroupId} with ${groupGenres.length} genres: ${groupGenres.join(', ')}`);
+
+  // Run only for this KV group and save partial results
+  (async () => {
+    const startTime = Date.now();
+    const ngList = await getNGList();
+    const originalDerivedCount = ngList.derivedVideoIds.length;
+    console.log(`KV Group ${kvGroupId} NG list: ${ngList.videoIds.length} video IDs, ${ngList.videoTitles.exact.length + ngList.videoTitles.partial.length} titles, ${ngList.authorIds.length} author IDs, ${ngList.authorNames.exact.length + ngList.authorNames.partial.length} author names, ${ngList.derivedVideoIds.length} derived`);
+
+    // Process each genre sequentially within group
+    const results = [];
+    for (const genre of groupGenres) {
+      const result = await processGenre(genre, ngList);
+      results.push(result);
+
+      // Add delay between genres to avoid rate limiting on getthumbinfo API
+      if (genre !== groupGenres[groupGenres.length - 1]) {
+        await new Promise(resolve => setTimeout(resolve, 5000));
+      }
+    }
+
+    // Save partial results
+    const tmpDir = './tmp';
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, `ranking-kv-group-${kvGroupId}.json`),
+      JSON.stringify(results, null, 2)
+    );
+
+    // Check if new derived entries were found
+    const newDerivedCount = ngList.derivedVideoIds.length;
+    if (newDerivedCount > originalDerivedCount) {
+      const newlyAdded = newDerivedCount - originalDerivedCount;
+      console.log(`KV Group ${kvGroupId} found ${newlyAdded} new derived NG entries (${originalDerivedCount} → ${newDerivedCount})`);
+
+      // Save the new derived entries for aggregation
+      const derivedData = {
+        originalCount: originalDerivedCount,
+        newCount: newDerivedCount,
+        newEntries: ngList.derivedVideoIds.slice(originalDerivedCount),
+        allEntries: ngList.derivedVideoIds
+      };
+
+      await fs.writeFile(
+        path.join(tmpDir, `ng-derived-kv-group-${kvGroupId}.json`),
+        JSON.stringify(derivedData, null, 2)
+      );
+
+      console.log(`Saved ${newlyAdded} new derived entries to ng-derived-kv-group-${kvGroupId}.json`);
+    }
+
+    const duration = Date.now() - startTime;
+    console.log(`KV Group ${kvGroupId} completed in ${Math.round(duration / 1000)}s with ${results.length} genres`);
+
+    // Exit with error if we didn't get all expected genres
+    if (results.length !== groupGenres.length) {
+      console.error(`ERROR: Expected ${groupGenres.length} genres but only processed ${results.length}`);
+      process.exit(1);
+    }
+  })().catch(error => {
+    console.error(`KV Group ${kvGroupId} failed catastrophically:`, error);
+    process.exit(1);
+  });
+} else if (process.argv[2] === '--group') {
+  // Legacy: Check if this is being run for a specific group (8-group strategy)
   // Group mode for GitHub Actions matrix strategy
   const groupId = parseInt(process.argv[3]);
   const totalGroups = parseInt(process.argv[4] || '8');


### PR DESCRIPTION
## Summary

カスタムランキングが表示されない問題（タグデータ欠落）を修正するため、**KVグループベースのローテーション方式**を実装しました。

### 問題点
- 8グループの並列実行でgetthumbinfo APIに約8000件の同時リクエストが発生
- HTTP 403エラーにより61%（14/23）のジャンルでタグ取得失敗
- max-parallel=1は2時間以上かかり、30分更新サイクルと非互換

### 解決策
GENRE_GROUPS（3グループ）に合わせたローテーション:

| Set | KVグループ | ジャンル数 | ジャンル |
|-----|----------|-----------|---------|
| A | RANKING_GROUP_1 | 8 | all, game, anime, vocaloid, voicesynthesis, entertainment, music, sing |
| B | RANKING_GROUP_2 | 8 | dance, play, commentary, cooking, travel, nature, vehicle, technology |
| C | RANKING_GROUP_3 | 7 | society, mmd, vtuber, radio, sports, animal, other |

### 設計上の利点

| 観点 | 旧設計 (8グループ) | 新設計 (KVグループ) |
|------|-------------------|-------------------|
| ジャンル均等性 | 6:6:11 (不均等) | 8:8:7 (均等) |
| KVマージ | 必要（複雑） | 不要（シンプル） |
| データ鮮度 | KV内で不整合 | KV単位で一貫 |
| ロールバック | マージ履歴残る | 完全に安全 |
| 互換性 | 複雑なマッピング | 直接対応 |

### 変更ファイル

**ワークフロー (`update-ranking-parallel.yml`)**
- `--kv-group` オプションを使用（`--group` から変更）
- matrixを [1, 2, 3] に変更
- ファイル名を `ranking-kv-group-N.json` に変更

**スクリプト (`update-ranking-parallel-v2.ts`)**
- `--kv-group` オプションを追加（GENRE_GROUPS使用）
- 既存の `--group` オプションは後方互換性のため維持

**集約スクリプト (`aggregate-ranking-results-direct.ts`)**
- KVグループモードの検出（`KV_GROUP_MODE` 環境変数）
- 両方のファイル形式をサポート

### ロールバック手順

問題が発生した場合:
```bash
# 1. コードを戻す
git revert <commit>

# 2. ワークフローは自動的に旧モードで動作
# KVデータ形式は変更されていないため、互換性あり
```

## Test plan
- [ ] 手動トリガーでKV Group 1, 2, 3をそれぞれ実行
- [ ] 各グループ実行後、対象ジャンルのタグデータが正しく取得されていることを確認
- [ ] カスタムランキング（例：「真夏の夜の淫夢」）が表示されることを確認
- [ ] ALLを選択して全グループ同時実行をテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Scheduling moved to a three-set rotation with gated, parallelized execution and manual override.
  * Pipeline now targets and gates work per group, preserves partial updates, and merges new data with existing entries.
  * Aggregation always runs but gracefully skips when no group data exists; artifacts and logs are scoped per group.
  * Enhanced logging and visibility for group selection, writes, and completion.

* **New Features**
  * Per-group partial-result publishing and robust merge-aware writes to persistent storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->