### PR TITLE
fix: add missing TagFetchRunStats exports

### DIFF
--- a/lib/tag-fetcher-simple.ts
+++ b/lib/tag-fetcher-simple.ts
@@ -45,6 +45,56 @@ export interface TagDetail {
   isLocked: boolean
 }
 
+/**
+ * タグ取得の統計情報
+ */
+export interface TagFetchRunStats {
+  startedAt: string
+  completedAt: string
+  totalItems: number
+  itemsWithTags: number
+  cacheHits: number
+  cacheRate: number
+  nicologFetches: number
+  nicologSuccesses: number
+  nicologFailures: Record<string, number>
+  thumbFetches: number
+  thumbSuccesses: number
+  thumbFailures: Record<string, number>
+}
+
+// モジュールレベルの統計情報
+let runStats: TagFetchRunStats = createEmptyStats()
+
+function createEmptyStats(): TagFetchRunStats {
+  return {
+    startedAt: new Date().toISOString(),
+    completedAt: '',
+    totalItems: 0,
+    itemsWithTags: 0,
+    cacheHits: 0,
+    cacheRate: 0,
+    nicologFetches: 0,
+    nicologSuccesses: 0,
+    nicologFailures: {},
+    thumbFetches: 0,
+    thumbSuccesses: 0,
+    thumbFailures: {},
+  }
+}
+
+export function getTagFetchRunStats(): TagFetchRunStats {
+  return {
+    ...runStats,
+    completedAt: new Date().toISOString(),
+    cacheRate: runStats.totalItems > 0 ? runStats.cacheHits / runStats.totalItems : 0,
+  }
+}
+
+export function resetTagFetchRunStats(): void {
+  runStats = createEmptyStats()
+}
+
 type TagFetchResult = { ok: true; tags: TagDetail[] } | { ok: false; reason: string }
 
 const isTagFetchFailure = (result: TagFetchResult): result is { ok: false; reason: string } => {


### PR DESCRIPTION
## 問題
ランキング更新ワークフローが失敗
```
SyntaxError: The requested module '../lib/tag-fetcher-simple' does not provide an export named 'getTagFetchRunStats'
```

## 修正内容
`lib/tag-fetcher-simple.ts` に以下を追加:
- `TagFetchRunStats` インターフェース
- `getTagFetchRunStats()` 関数
- `resetTagFetchRunStats()` 関数

これらは `scripts/update-ranking-parallel-v2.ts` で使用されています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced tag fetch run statistics tracking with new public APIs to retrieve current metrics and reset statistics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->