### PR TITLE
fix(workers): move auth to secrets and lock debug access

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -32,6 +32,24 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Sync Cloudflare Worker secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER_AUTH_KEY: ${{ secrets.WORKER_AUTH_KEY }}
+          SENTRY_WORKER_DSN: ${{ secrets.SENTRY_WORKER_DSN }}
+        run: |
+          if [ -z "$WORKER_AUTH_KEY" ]; then
+            echo "WORKER_AUTH_KEY secret is not configured"
+            exit 1
+          fi
+
+          printf '%s' "$WORKER_AUTH_KEY" | wrangler secret put WORKER_AUTH_KEY -c ${{ inputs.wrangler_config }}
+
+          if [ -n "$SENTRY_WORKER_DSN" ]; then
+            printf '%s' "$SENTRY_WORKER_DSN" | wrangler secret put SENTRY_WORKER_DSN -c ${{ inputs.wrangler_config }}
+          fi
       
       - name: Deploy Worker
         env:

--- a/__tests__/unit/workers-debug-auth.test.ts
+++ b/__tests__/unit/workers-debug-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { hasWorkerDebugAccess } from '@/workers/utils/debug-auth'
+
+describe('hasWorkerDebugAccess', () => {
+  it('accepts bearer authorization with the worker auth key', () => {
+    const request = new Request('https://nico-rank.com/api/debug', {
+      headers: {
+        Authorization: 'Bearer test-worker-key',
+      },
+    })
+
+    expect(hasWorkerDebugAccess(request, 'test-worker-key')).toBe(true)
+  })
+
+  it('accepts X-Worker-Auth with the worker auth key', () => {
+    const request = new Request('https://nico-rank.com/api/debug', {
+      headers: {
+        'X-Worker-Auth': 'test-worker-key',
+      },
+    })
+
+    expect(hasWorkerDebugAccess(request, 'test-worker-key')).toBe(true)
+  })
+
+  it('rejects requests without a matching worker auth key', () => {
+    const request = new Request('https://nico-rank.com/api/debug')
+
+    expect(hasWorkerDebugAccess(request, 'test-worker-key')).toBe(false)
+  })
+})

--- a/docs/sentry-observability.md
+++ b/docs/sentry-observability.md
@@ -24,6 +24,7 @@
 - Workers environment:
   - `env.ENVIRONMENT ?? 'production'`
 - release は必須にしていません。Debug IDs ベースで sourcemap を解決します。
+- Worker runtime secrets (`WORKER_AUTH_KEY`, `SENTRY_WORKER_DSN`) は tracked `wrangler*.toml` に置かず、Cloudflare Secrets に設定します。
 
 ## Privacy Policy
 - `sendDefaultPii: false`

--- a/scripts/deploy-green-worker.sh
+++ b/scripts/deploy-green-worker.sh
@@ -29,7 +29,6 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     read -p "今すぐ設定しますか? (y/N): " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "現在のキー: c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493"
         wrangler secret put WORKER_AUTH_KEY -c "$CONFIG_FILE"
     else
         echo "❌ セキュリティ設定が未完了のため、デプロイを中止します"

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,8 +3,8 @@
 interface Env {
 	RANKING_DATA: KVNamespace;
 	MAINTENANCE_FLAGS: KVNamespace;
-	VERCEL_DEPLOYMENT_URL: "https://nico-ranking-custom-yjsns-projects.vercel.app";
-	WORKER_AUTH_KEY: "c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493";
+	VERCEL_DEPLOYMENT_URL: string;
+	WORKER_AUTH_KEY: string;
 	R2_BUCKET: R2Bucket;
 	WORKER_BLUE: Fetcher;
 	WORKER_GREEN: Fetcher;

--- a/workers/api-gateway-green-20250726.ts
+++ b/workers/api-gateway-green-20250726.ts
@@ -31,6 +31,7 @@
 import { decodeRankingData } from './utils/html-decode'
 import { applyCORSHeaders, createOptionsResponse } from './utils/cors-config'
 import { handleWithCache } from './utils/cache-handler'
+import { hasWorkerDebugAccess } from './utils/debug-auth'
 import { Sentry, captureWorkerException, createWorkerSentryOptions, sanitizeUrlForSentry } from './sentry.js'
 
 interface Env {
@@ -255,11 +256,21 @@ const handler: ExportedHandler<Env> = {
     
     // /api/debug エンドポイント
     if (url.pathname === '/api/debug') {
+      if (!hasWorkerDebugAccess(request, env.WORKER_AUTH_KEY)) {
+        const origin = request.headers.get('Origin')
+        const notFoundResponse = new Response('Not Found', {
+          status: 404,
+          headers: {
+            'Content-Type': 'text/plain',
+          },
+        })
+        return applyCORSHeaders(notFoundResponse, origin, securityHeaders)
+      }
+
       const { debugInfo, secondsUntilUpdate } = calculateDynamicTTL()
       
       const debugOutput = {
         time: new Date().toISOString(),
-        headers: Object.fromEntries(request.headers.entries()),
         worker: 'api-gateway-green-20250726',
         version: 'green-20250726-dynamic-ttl',
         features: ['dynamic-ttl', 'etag-support', 'html-decode', 'smart-router-compatible'],
@@ -273,6 +284,7 @@ const handler: ExportedHandler<Env> = {
       const debugResponse = new Response(JSON.stringify(debugOutput, null, 2), {
         status: 200,
         headers: {
+          'Cache-Control': 'no-store',
           'Content-Type': 'application/json',
           'X-Worker-Version': 'green-20250726-unified-cors'
         }

--- a/workers/smart-router-20250706.ts
+++ b/workers/smart-router-20250706.ts
@@ -8,6 +8,7 @@
 /// <reference types="@cloudflare/workers-types" />
 
 import { applyCORSHeaders, createOptionsResponse } from './utils/cors-config'
+import { hasWorkerDebugAccess } from './utils/debug-auth'
 import { Sentry, captureWorkerException, createWorkerSentryOptions, sanitizeUrlForSentry } from './sentry.js'
 
 interface Env {
@@ -68,6 +69,17 @@ const handler: ExportedHandler<Env> = {
     if (request.method === 'OPTIONS') {
       const origin = request.headers.get('Origin')
       return createOptionsResponse(origin)
+    }
+
+    if (url.pathname === '/api/debug' && !hasWorkerDebugAccess(request, env.WORKER_AUTH_KEY)) {
+      const origin = request.headers.get('Origin')
+      const notFoundResponse = new Response('Not Found', {
+        status: 404,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      })
+      return applyCORSHeaders(notFoundResponse, origin, securityHeaders)
     }
 
     try {

--- a/workers/utils/debug-auth.ts
+++ b/workers/utils/debug-auth.ts
@@ -1,0 +1,11 @@
+export function hasWorkerDebugAccess(request: Request, workerAuthKey?: string) {
+  if (!workerAuthKey) return false
+
+  const authHeader = request.headers.get('Authorization')
+  if (authHeader === `Bearer ${workerAuthKey}`) {
+    return true
+  }
+
+  const workerHeader = request.headers.get('X-Worker-Auth')
+  return workerHeader === workerAuthKey
+}

--- a/workers/video-stats-updater/wrangler.toml
+++ b/workers/video-stats-updater/wrangler.toml
@@ -21,8 +21,8 @@ bucket_name = "nico-ranking"
 
 # Worker auth key for manual triggers
 [vars]
-WORKER_AUTH_KEY = "c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493"
 ENVIRONMENT = "production"
+# WORKER_AUTH_KEY and SENTRY_WORKER_DSN are set via Cloudflare Secrets
 
 # Environment-specific settings
 [env.production]

--- a/wrangler-green.toml
+++ b/wrangler-green.toml
@@ -32,8 +32,8 @@ simple = { limit = 120, period = 60 }
 # 環境変数
 [vars]
 VERCEL_DEPLOYMENT_URL = "https://nico-ranking-custom-yjsns-projects.vercel.app"
-WORKER_AUTH_KEY = "c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493"
 ENVIRONMENT = "green"
+# WORKER_AUTH_KEY and SENTRY_WORKER_DSN are set via Cloudflare Secrets
 
 # TypeScript設定
 [build]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,8 +34,8 @@ simple = { limit = 600, period = 60 }
 # 環境変数
 [vars]
 VERCEL_DEPLOYMENT_URL = "https://nico-ranking-custom-yjsns-projects.vercel.app"
-WORKER_AUTH_KEY = "c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493"
 ENVIRONMENT = "production"
+# WORKER_AUTH_KEY and SENTRY_WORKER_DSN are set via Cloudflare Secrets
 
 # Custom domain
 [[routes]]
@@ -88,8 +88,8 @@ simple = { limit = 600, period = 60 }
 # 環境変数（プレビュー用）
 [env.preview.vars]
 VERCEL_DEPLOYMENT_URL = "https://nico-ranking-custom-yjsns-projects.vercel.app"
-WORKER_AUTH_KEY = "preview-c8d0aeead3a77d1a88438d5275398fda20efd5db8f98186c524d478362ffa493"
 ENVIRONMENT = "preview"
+# WORKER_AUTH_KEY and SENTRY_WORKER_DSN are set via Cloudflare Secrets
 
 # Service Bindings - プレビュー環境でも同じWorkerに接続
 [[env.preview.services]]


### PR DESCRIPTION
Move the worker auth key out of tracked Cloudflare config and gate the live worker debug endpoint behind that secret.

The current repository state still exposed `WORKER_AUTH_KEY` in tracked Wrangler files, a generated type file, and an interactive deploy helper. The active Green worker also returned request headers and internal runtime details from `/api/debug` without authentication. This change removes the tracked key material, adds a shared debug auth helper, and updates the Cloudflare deploy workflow to sync `WORKER_AUTH_KEY` and `SENTRY_WORKER_DSN` into Cloudflare Secrets before deploying.

I also added a focused unit test for the debug auth helper and updated the Sentry docs to reflect the Cloudflare Secrets requirement.

Out of band operational work completed in parallel:
- added GitHub Actions secrets `WORKER_AUTH_KEY` and `SENTRY_WORKER_DSN`
- prepared this branch for Cloudflare redeploy after merge