### PR TITLE
fix(ci): run worker deploys with npx wrangler

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -45,10 +45,10 @@ jobs:
             exit 1
           fi
 
-          printf '%s' "$WORKER_AUTH_KEY" | wrangler secret put WORKER_AUTH_KEY -c ${{ inputs.wrangler_config }}
+          printf '%s' "$WORKER_AUTH_KEY" | npx wrangler secret put WORKER_AUTH_KEY -c ${{ inputs.wrangler_config }}
 
           if [ -n "$SENTRY_WORKER_DSN" ]; then
-            printf '%s' "$SENTRY_WORKER_DSN" | wrangler secret put SENTRY_WORKER_DSN -c ${{ inputs.wrangler_config }}
+            printf '%s' "$SENTRY_WORKER_DSN" | npx wrangler secret put SENTRY_WORKER_DSN -c ${{ inputs.wrangler_config }}
           fi
       
       - name: Deploy Worker
@@ -60,11 +60,11 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_WORKERS }}
         run: |
           if [ "${{ inputs.wrangler_config }}" != "wrangler.toml" ]; then
-            wrangler deploy ${{ inputs.worker_file }} \
+            npx wrangler deploy ${{ inputs.worker_file }} \
               --name ${{ inputs.worker_name }} \
               -c ${{ inputs.wrangler_config }}
           else
-            wrangler deploy ${{ inputs.worker_file }} \
+            npx wrangler deploy ${{ inputs.worker_file }} \
               --name ${{ inputs.worker_name }}
           fi
       
@@ -74,7 +74,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "Worker deployed: ${{ inputs.worker_name }}"
-          wrangler tail ${{ inputs.worker_name }} --format=pretty &
+          npx wrangler tail ${{ inputs.worker_name }} --format=pretty &
           TAIL_PID=$!
           sleep 10
           kill $TAIL_PID || true


### PR DESCRIPTION
Fix the Cloudflare worker deploy workflow so it can actually sync secrets and deploy workers on GitHub Actions.

The previous change correctly moved `WORKER_AUTH_KEY` and `SENTRY_WORKER_DSN` into Cloudflare Secrets, but the workflow still invoked `wrangler` directly. On GitHub-hosted runners that binary is not on PATH after `npm ci`, so every redeploy attempt failed before the secret sync step could run. This switches the workflow to `npx wrangler` for secret sync, deploy, and tail.

This is the follow-up needed to complete the production rollout for the worker security fix and the Sentry worker secret wiring.