### PR TITLE
fix(ci): always pass wrangler config

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -41,14 +41,9 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT_WORKERS }}
         run: |
-          if [ "${{ inputs.wrangler_config }}" != "wrangler.toml" ]; then
-            npx wrangler deploy ${{ inputs.worker_file }} \
-              --name ${{ inputs.worker_name }} \
-              -c ${{ inputs.wrangler_config }}
-          else
-            npx wrangler deploy ${{ inputs.worker_file }} \
-              --name ${{ inputs.worker_name }}
-          fi
+          npx wrangler deploy ${{ inputs.worker_file }} \
+            --name ${{ inputs.worker_name }} \
+            -c ${{ inputs.wrangler_config }}
 
       - name: Sync Cloudflare Worker secrets
         env:


### PR DESCRIPTION
## Summary
- always pass the requested wrangler config to deploy-worker.yml
- avoid accidentally resolving workers/wrangler.toml during root worker deploys
- keep the secret migration order from PR #378 intact

## Testing
- python3 YAML parse for .github/workflows/deploy-worker.yml
- git diff --check