### PR TITLE
feat: add watch later queue

### DIFF
--- a/__tests__/unit/components/watch-later-queue.test.tsx
+++ b/__tests__/unit/components/watch-later-queue.test.tsx
@@ -46,7 +46,7 @@ describe('WatchLaterQueue', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'あとで見る 1件' }))
     expect(
-      screen.getByRole('dialog', { name: 'あとで見る' }),
+      screen.getByRole('complementary', { name: 'あとで見る' }),
     ).toBeInTheDocument()
     expect(screen.getByText('テスト動画')).toBeInTheDocument()
   })

--- a/__tests__/unit/components/watch-later-queue.test.tsx
+++ b/__tests__/unit/components/watch-later-queue.test.tsx
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '@/__tests__/test-utils'
+import { WatchLaterQueue } from '@/components/watch-later-queue'
+import {
+  WATCH_LATER_STORAGE_KEY,
+  addWatchLaterItem,
+  readWatchLaterItems,
+} from '@/lib/watch-later'
+import { navigateToVideo } from '@/lib/pwa-utils'
+import type { RankingItem } from '@/types/ranking'
+
+vi.mock('@/lib/pwa-utils', () => ({
+  navigateToVideo: vi.fn(),
+}))
+
+const video: RankingItem = {
+  id: 'sm12345',
+  title: 'テスト動画',
+  thumbURL: 'https://nicovideo.cdn.nimg.jp/thumbnails/12345/12345.jpg',
+  rank: 1,
+  views: 100,
+  comments: 10,
+  mylists: 5,
+  likes: 20,
+  authorName: '投稿者',
+}
+
+describe('WatchLaterQueue', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.clearAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+  })
+
+  it('shows count and opens the drawer with stored items', async () => {
+    addWatchLaterItem(video)
+    render(<WatchLaterQueue />)
+
+    expect(
+      screen.getByRole('button', { name: 'あとで見る 1件' }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'あとで見る 1件' }))
+    expect(
+      screen.getByRole('dialog', { name: 'あとで見る' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('テスト動画')).toBeInTheDocument()
+  })
+
+  it('removes an item from the drawer', async () => {
+    addWatchLaterItem(video)
+    render(<WatchLaterQueue />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'あとで見る 1件' }))
+    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+
+    await waitFor(() => {
+      expect(readWatchLaterItems()).toEqual([])
+    })
+    expect(
+      screen.getByText('右クリックまたは長押しから動画を追加できます。'),
+    ).toBeInTheDocument()
+  })
+
+  it('copies all URLs', async () => {
+    addWatchLaterItem(video)
+    render(<WatchLaterQueue />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'あとで見る 1件' }))
+    fireEvent.click(screen.getByRole('button', { name: 'URLをまとめてコピー' }))
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'https://www.nicovideo.jp/watch/sm12345',
+      )
+    })
+  })
+
+  it('opens the top item through the shared PWA navigation helper', async () => {
+    addWatchLaterItem(video)
+    render(<WatchLaterQueue />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'あとで見る 1件' }))
+    fireEvent.click(screen.getByRole('button', { name: '上から順に開く' }))
+
+    await waitFor(() => {
+      expect(navigateToVideo).toHaveBeenCalledWith(
+        'https://www.nicovideo.jp/watch/sm12345',
+      )
+    })
+    expect(readWatchLaterItems()[0].openedAt).toBeTruthy()
+  })
+
+  it('syncs when storage changes in another tab', async () => {
+    render(<WatchLaterQueue />)
+    expect(
+      screen.getByRole('button', { name: 'あとで見る 0件' }),
+    ).toBeInTheDocument()
+
+    window.localStorage.setItem(
+      WATCH_LATER_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: video.id,
+          title: video.title,
+          url: 'https://www.nicovideo.jp/watch/sm12345',
+          addedAt: '2026-05-20T01:00:00.000Z',
+        },
+      ]),
+    )
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: WATCH_LATER_STORAGE_KEY }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'あとで見る 1件' }),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/unit/video-context-menu.test.tsx
+++ b/__tests__/unit/video-context-menu.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { render } from '@/__tests__/test-utils'
 import { VideoContextMenu } from '@/components/video-context-menu'
+import { readWatchLaterItems } from '@/lib/watch-later'
 import type { RankingItem } from '@/types/ranking'
 import '../test-environment'
 
@@ -50,6 +51,7 @@ Object.defineProperty(navigator, 'clipboard', {
 describe('VideoContextMenu - サムネイル保存機能', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    window.localStorage.clear()
   })
 
   afterEach(() => {
@@ -71,6 +73,30 @@ describe('VideoContextMenu - サムネイル保存機能', () => {
     await waitFor(() => {
       expect(screen.getByText('サムネイル保存')).toBeInTheDocument()
     }, { timeout: 600 })
+  })
+
+  it('右クリックメニューからあとで見るに追加できる', async () => {
+    render(
+      <VideoContextMenu video={mockVideo} sourceContext={{ genre: 'game', period: '24h' }}>
+        <div>テストコンテンツ</div>
+      </VideoContextMenu>
+    )
+
+    const content = screen.getByText('テストコンテンツ')
+    fireEvent.contextMenu(content, { clientX: 100, clientY: 100 })
+
+    const addButton = await screen.findByText('あとで見るに追加')
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(readWatchLaterItems()).toHaveLength(1)
+    })
+    expect(readWatchLaterItems()[0]).toMatchObject({
+      id: 'sm12345',
+      sourceGenre: 'game',
+      sourcePeriod: '24h',
+    })
+    expect(screen.getByText('✓ あとで見るに追加しました')).toBeInTheDocument()
   })
 
   it('サムネイルURLが既に存在する場合、大きいサイズに変換してプロキシAPI経由でダウンロードされる', async () => {

--- a/__tests__/unit/watch-later.test.ts
+++ b/__tests__/unit/watch-later.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RankingItem } from '@/types/ranking'
+import {
+  WATCH_LATER_STORAGE_KEY,
+  addWatchLaterItem,
+  clearWatchLaterItems,
+  markWatchLaterItemOpened,
+  readWatchLaterItems,
+  removeWatchLaterItem,
+} from '@/lib/watch-later'
+
+const video: RankingItem = {
+  id: 'sm12345',
+  title: 'テスト動画',
+  thumbURL: 'https://nicovideo.cdn.nimg.jp/thumbnails/12345/12345.jpg',
+  rank: 1,
+  views: 100,
+  comments: 10,
+  mylists: 5,
+  likes: 20,
+  authorName: '投稿者',
+}
+
+describe('watch-later storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T01:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('adds a ranking item with source context', () => {
+    const result = addWatchLaterItem(video, {
+      genre: 'game',
+      period: '24h',
+      tag: '実況',
+    })
+
+    expect(result.added).toBe(true)
+    expect(result.items).toHaveLength(1)
+    expect(result.item).toMatchObject({
+      id: 'sm12345',
+      title: 'テスト動画',
+      url: 'https://www.nicovideo.jp/watch/sm12345',
+      sourceGenre: 'game',
+      sourcePeriod: '24h',
+      sourceTag: '実況',
+      addedAt: '2026-05-20T01:00:00.000Z',
+    })
+  })
+
+  it('deduplicates by video id', () => {
+    addWatchLaterItem(video)
+    const second = addWatchLaterItem({ ...video, title: '別タイトル' })
+
+    expect(second.added).toBe(false)
+    expect(readWatchLaterItems()).toHaveLength(1)
+    expect(readWatchLaterItems()[0].title).toBe('テスト動画')
+  })
+
+  it('removes, clears, and marks opened items', () => {
+    addWatchLaterItem(video)
+    markWatchLaterItemOpened(video.id)
+    expect(readWatchLaterItems()[0].openedAt).toBe('2026-05-20T01:00:00.000Z')
+
+    removeWatchLaterItem(video.id)
+    expect(readWatchLaterItems()).toEqual([])
+
+    addWatchLaterItem(video)
+    clearWatchLaterItems()
+    expect(window.localStorage.getItem(WATCH_LATER_STORAGE_KEY)).toBe('[]')
+  })
+})

--- a/app/(info)/contact/page.tsx
+++ b/app/(info)/contact/page.tsx
@@ -47,11 +47,11 @@ export default function ContactPage() {
           marginBottom: '20px',
           color: 'var(--text-secondary)',
         }}>
-          ニコラン(Re:turn)に関するご意見・ご要望・バグ報告は、管理者のXアカウント(@yjmnsub)にてお寄せください。
+          ニコラン(Re:turn)に関するご意見・ご要望・バグ報告は、管理者のXアカウント(@yjmnsub2)にてお寄せください。
         </p>
         
         <a
-          href="https://twitter.com/yjmnsub"
+          href="https://twitter.com/yjmnsub2"
           target="_blank"
           rel="noopener noreferrer"
           className="contact-link"
@@ -70,7 +70,7 @@ export default function ContactPage() {
         >
           <div>
             <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
-              @yjmnsub
+              @yjmnsub2
             </div>
             <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>
               管理者のXアカウント

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -1514,7 +1514,14 @@ export default function ClientPage({
           <ul key={`${ngListVersion}-${config.period}`} style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {finalDisplayItems.map((item) => (
               <li key={item.id} style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-                <VideoContextMenu video={item}>
+                <VideoContextMenu
+                  video={item}
+                  sourceContext={{
+                    genre: config.genre,
+                    period: config.period,
+                    tag: config.tag,
+                  }}
+                >
                   <RankingItemResponsive 
                     item={item}
                     disabled={isNavigating}

--- a/components/header-with-settings.tsx
+++ b/components/header-with-settings.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { SettingsModal } from './settings-modal'
 import { Navigation } from './navigation'
 import { ReloadButton } from './reload-button'
+import { WatchLaterQueue } from './watch-later-queue'
 import styles from './header.module.css'
 
 export function HeaderWithSettings() {
@@ -74,6 +75,7 @@ export function HeaderWithSettings() {
         </div>
         
         <div className={styles.headerButtons}>
+          <WatchLaterQueue />
           <ReloadButton />
           <button
             onClick={() => setIsSettingsOpen(true)}

--- a/components/video-context-menu.css
+++ b/components/video-context-menu.css
@@ -62,6 +62,15 @@
   background: var(--surface-secondary);
 }
 
+.video-context-menu__item--featured {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.video-context-menu__item--featured:hover {
+  background: var(--surface-hover);
+}
+
 .video-context-menu__item:active {
   background: var(--surface-hover);
   transform: scale(0.98);

--- a/components/video-context-menu.tsx
+++ b/components/video-context-menu.tsx
@@ -2,14 +2,17 @@
 
 import { useState, useRef, useEffect } from 'react'
 import type { RankingItem } from '@/types/ranking'
+import { navigateToVideo } from '@/lib/pwa-utils'
+import { addWatchLaterItem, type WatchLaterSource } from '@/lib/watch-later'
 import './video-context-menu.css'
 
 interface VideoContextMenuProps {
   video: RankingItem
   children: React.ReactNode
+  sourceContext?: WatchLaterSource
 }
 
-export function VideoContextMenu({ video, children }: VideoContextMenuProps) {
+export function VideoContextMenu({ video, children, sourceContext }: VideoContextMenuProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 })
   const [copySuccess, setCopySuccess] = useState(false)
@@ -20,6 +23,20 @@ export function VideoContextMenu({ video, children }: VideoContextMenuProps) {
   // 動画URLを生成
   const videoUrl = `https://www.nicovideo.jp/watch/${video.id}`
   const shareTitle = `${video.title} - ニコニコ動画`
+
+  const openVideo = () => {
+    navigateToVideo(videoUrl)
+    closeMenu()
+  }
+
+  const addToWatchLater = () => {
+    const result = addWatchLaterItem(video, sourceContext)
+    setSuccessMessage(result.added ? '✓ あとで見るに追加しました' : '✓ すでに追加済みです')
+    setCopySuccess(true)
+    setTimeout(() => {
+      closeMenu()
+    }, 1500)
+  }
   
   // 長押し開始
   const handleTouchStart = (e: React.TouchEvent) => {
@@ -243,6 +260,24 @@ export function VideoContextMenu({ video, children }: VideoContextMenuProps) {
               </div>
             ) : (
               <>
+                <button
+                  className="video-context-menu__item"
+                  onClick={openVideo}
+                >
+                  <span className="video-context-menu__icon" aria-hidden="true">↗</span>
+                  動画を開く
+                </button>
+
+                <button
+                  className="video-context-menu__item video-context-menu__item--featured"
+                  onClick={addToWatchLater}
+                >
+                  <span className="video-context-menu__icon" aria-hidden="true">＋</span>
+                  あとで見るに追加
+                </button>
+
+                <div className="video-context-menu__divider" />
+
                 <button
                   className="video-context-menu__item"
                   onClick={() => copyToClipboard(video.title, 'title')}

--- a/components/watch-later-queue.css
+++ b/components/watch-later-queue.css
@@ -1,0 +1,279 @@
+.watch-later-queue__button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    transform 0.2s;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.watch-later-queue__button:hover {
+  background: rgba(255, 255, 255, 0.32);
+  transform: scale(1.03);
+}
+
+.watch-later-queue__button-text {
+  font-size: 13px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.watch-later-queue__button-text--mobile {
+  display: none;
+}
+
+.watch-later-queue__count {
+  min-width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  border-radius: 6px;
+  background: var(--primary-color);
+  color: var(--button-text-active);
+  font-size: 13px;
+  line-height: 1;
+}
+
+.watch-later-queue__layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+}
+
+.watch-later-queue__backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: rgba(0, 0, 0, 0.42);
+  cursor: default;
+}
+
+.watch-later-queue__panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, calc(100vw - 24px));
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-color);
+  border-left: 1px solid var(--border-color);
+  box-shadow: var(--shadow-xl);
+  color: var(--text-primary);
+}
+
+.watch-later-queue__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.watch-later-queue__header h2 {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.watch-later-queue__header p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.watch-later-queue__close {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.watch-later-queue__message {
+  margin: 12px 18px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--surface-secondary);
+  color: var(--success-color);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.watch-later-queue__list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 14px 18px;
+  list-style: none;
+}
+
+.watch-later-queue__item {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 12px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--surface-secondary);
+}
+
+.watch-later-queue__thumbnail {
+  width: 96px;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 6px;
+  background: var(--surface-hover);
+}
+
+.watch-later-queue__thumbnail--empty {
+  border: 1px dashed var(--border-color);
+}
+
+.watch-later-queue__meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.watch-later-queue__title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--link-color);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.watch-later-queue__subline {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watch-later-queue__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.watch-later-queue__actions button,
+.watch-later-queue__footer button {
+  min-height: 36px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--surface-color);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.watch-later-queue__actions button {
+  padding: 6px 8px;
+}
+
+.watch-later-queue__footer {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  padding: 14px 18px max(14px, env(safe-area-inset-bottom));
+  border-top: 1px solid var(--border-color);
+  background: var(--surface-color);
+}
+
+.watch-later-queue__footer button {
+  min-height: 44px;
+  padding: 8px 12px;
+}
+
+.watch-later-queue__footer button:first-child {
+  background: var(--primary-color);
+  color: var(--button-text-active);
+  border-color: var(--primary-color);
+}
+
+.watch-later-queue__footer button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.watch-later-queue__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .watch-later-queue__button {
+    min-height: 44px;
+    gap: 6px;
+    padding: 4px 7px;
+  }
+
+  .watch-later-queue__button-text--desktop {
+    display: none;
+  }
+
+  .watch-later-queue__button-text--mobile {
+    display: inline;
+  }
+
+  .watch-later-queue__panel {
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: min(78dvh, 640px);
+    border-top: 1px solid var(--border-color);
+    border-left: 0;
+    border-radius: 8px 8px 0 0;
+  }
+
+  .watch-later-queue__item {
+    grid-template-columns: 88px minmax(0, 1fr);
+  }
+
+  .watch-later-queue__thumbnail {
+    width: 88px;
+  }
+
+  .watch-later-queue__actions button {
+    min-height: 44px;
+    padding: 8px 10px;
+  }
+}

--- a/components/watch-later-queue.css
+++ b/components/watch-later-queue.css
@@ -51,9 +51,11 @@
   position: fixed;
   inset: 0;
   z-index: 1200;
+  pointer-events: none;
 }
 
 .watch-later-queue__backdrop {
+  display: none;
   position: fixed;
   inset: 0;
   border: 0;
@@ -63,16 +65,18 @@
 
 .watch-later-queue__panel {
   position: fixed;
-  top: 0;
-  right: 0;
-  width: min(420px, calc(100vw - 24px));
-  height: 100dvh;
+  top: 92px;
+  right: 16px;
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(58dvh, 520px);
   display: flex;
   flex-direction: column;
   background: var(--surface-color);
-  border-left: 1px solid var(--border-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
   box-shadow: var(--shadow-xl);
   color: var(--text-primary);
+  pointer-events: auto;
 }
 
 .watch-later-queue__header {
@@ -237,7 +241,22 @@
   line-height: 1.6;
 }
 
+@media (min-width: 1900px) {
+  .watch-later-queue__panel {
+    right: max(24px, calc((100vw - 1200px) / 2 - 344px));
+    max-height: min(72dvh, 640px);
+  }
+}
+
 @media (max-width: 640px) {
+  .watch-later-queue__layer {
+    pointer-events: auto;
+  }
+
+  .watch-later-queue__backdrop {
+    display: block;
+  }
+
   .watch-later-queue__button {
     min-height: 44px;
     gap: 6px;
@@ -259,6 +278,7 @@
     left: 0;
     width: 100vw;
     height: min(78dvh, 640px);
+    max-height: none;
     border-top: 1px solid var(--border-color);
     border-left: 0;
     border-radius: 8px 8px 0 0;

--- a/components/watch-later-queue.tsx
+++ b/components/watch-later-queue.tsx
@@ -8,6 +8,8 @@ import { useWatchLaterQueueActions } from '@/hooks/use-watch-later-queue-actions
 import type { WatchLaterItem } from '@/lib/watch-later'
 import './watch-later-queue.css'
 
+const WATCH_LATER_PANEL_ID = 'watch-later-queue-panel'
+
 function WatchLaterItemRow({
   item,
   onOpen,
@@ -79,6 +81,19 @@ export function WatchLaterQueue() {
     setMounted(true)
   }, [])
 
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
+
   const layer = isOpen ? (
     <div className="watch-later-queue__layer" role="presentation">
       <button
@@ -88,9 +103,8 @@ export function WatchLaterQueue() {
         onClick={() => setIsOpen(false)}
       />
       <aside
+        id={WATCH_LATER_PANEL_ID}
         className="watch-later-queue__panel"
-        role="dialog"
-        aria-modal="true"
         aria-label="あとで見る"
         aria-live="polite"
       >
@@ -163,6 +177,7 @@ export function WatchLaterQueue() {
         className="watch-later-queue__button"
         aria-label={`あとで見る ${count}件`}
         aria-expanded={isOpen}
+        aria-controls={WATCH_LATER_PANEL_ID}
         onClick={() => setIsOpen(true)}
       >
         <span className="watch-later-queue__button-text watch-later-queue__button-text--desktop">

--- a/components/watch-later-queue.tsx
+++ b/components/watch-later-queue.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { OptimizedImage } from './optimized-image'
+import { useWatchLater } from '@/hooks/use-watch-later'
+import { navigateToVideo } from '@/lib/pwa-utils'
+import type { WatchLaterItem } from '@/lib/watch-later'
+import './watch-later-queue.css'
+
+function WatchLaterItemRow({
+  item,
+  onOpen,
+  onOpenAndRemove,
+  onRemove,
+}: {
+  item: WatchLaterItem
+  onOpen: (item: WatchLaterItem) => void
+  onOpenAndRemove: (item: WatchLaterItem) => void
+  onRemove: (id: string) => void
+}) {
+  return (
+    <li className="watch-later-queue__item">
+      {item.thumbURL ? (
+        <OptimizedImage
+          className="watch-later-queue__thumbnail"
+          src={item.thumbURL}
+          alt=""
+          width={96}
+          height={54}
+          loading="lazy"
+        />
+      ) : (
+        <div className="watch-later-queue__thumbnail watch-later-queue__thumbnail--empty" />
+      )}
+      <div className="watch-later-queue__meta">
+        <div className="watch-later-queue__title" title={item.title}>
+          {item.title}
+        </div>
+        <div className="watch-later-queue__subline">
+          {item.authorName || item.id}
+          {item.openedAt ? ' / 開封済み' : ''}
+        </div>
+        <div className="watch-later-queue__actions">
+          <button type="button" onClick={() => onOpen(item)}>
+            開く
+          </button>
+          <button type="button" onClick={() => onOpenAndRemove(item)}>
+            開いて削除
+          </button>
+          <button type="button" onClick={() => onRemove(item.id)}>
+            削除
+          </button>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+export function WatchLaterQueue() {
+  const { items, count, removeItem, clearItems, markOpened } = useWatchLater()
+  const [isOpen, setIsOpen] = useState(false)
+  const [message, setMessage] = useState('')
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const openItem = (item: WatchLaterItem) => {
+    markOpened(item.id)
+    navigateToVideo(item.url)
+  }
+
+  const openAndRemove = (item: WatchLaterItem) => {
+    removeItem(item.id)
+    navigateToVideo(item.url)
+  }
+
+  const openFirst = () => {
+    const first = items[0]
+    if (!first) return
+    openItem(first)
+  }
+
+  const copyAllUrls = async () => {
+    if (items.length === 0) return
+    try {
+      await navigator.clipboard.writeText(
+        items.map((item) => item.url).join('\n'),
+      )
+      setMessage('URLをコピーしました')
+      window.setTimeout(() => setMessage(''), 1800)
+    } catch {
+      setMessage('コピーに失敗しました')
+      window.setTimeout(() => setMessage(''), 1800)
+    }
+  }
+
+  const layer = isOpen ? (
+    <div className="watch-later-queue__layer" role="presentation">
+      <button
+        type="button"
+        className="watch-later-queue__backdrop"
+        aria-label="あとで見るを閉じる"
+        onClick={() => setIsOpen(false)}
+      />
+      <aside
+        className="watch-later-queue__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="あとで見る"
+        aria-live="polite"
+      >
+        <header className="watch-later-queue__header">
+          <div>
+            <h2>あとで見る</h2>
+            <p>{count}件の動画</p>
+          </div>
+          <button
+            type="button"
+            className="watch-later-queue__close"
+            aria-label="閉じる"
+            onClick={() => setIsOpen(false)}
+          >
+            ×
+          </button>
+        </header>
+
+        {message && <div className="watch-later-queue__message">{message}</div>}
+
+        {items.length > 0 ? (
+          <ul className="watch-later-queue__list">
+            {items.map((item) => (
+              <WatchLaterItemRow
+                key={item.id}
+                item={item}
+                onOpen={openItem}
+                onOpenAndRemove={openAndRemove}
+                onRemove={removeItem}
+              />
+            ))}
+          </ul>
+        ) : (
+          <div className="watch-later-queue__empty">
+            右クリックまたは長押しから動画を追加できます。
+          </div>
+        )}
+
+        <footer className="watch-later-queue__footer">
+          <button
+            type="button"
+            onClick={openFirst}
+            disabled={items.length === 0}
+          >
+            上から順に開く
+          </button>
+          <button
+            type="button"
+            onClick={copyAllUrls}
+            disabled={items.length === 0}
+          >
+            URLをまとめてコピー
+          </button>
+          <button
+            type="button"
+            onClick={clearItems}
+            disabled={items.length === 0}
+          >
+            すべて削除
+          </button>
+        </footer>
+      </aside>
+    </div>
+  ) : null
+
+  return (
+    <>
+      <button
+        type="button"
+        className="watch-later-queue__button"
+        aria-label={`あとで見る ${count}件`}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen(true)}
+      >
+        <span className="watch-later-queue__button-text watch-later-queue__button-text--desktop">
+          あとで見る
+        </span>
+        <span className="watch-later-queue__button-text watch-later-queue__button-text--mobile">
+          あと
+        </span>
+        <span className="watch-later-queue__count">{count}</span>
+      </button>
+
+      {mounted && layer ? createPortal(layer, document.body) : null}
+    </>
+  )
+}

--- a/components/watch-later-queue.tsx
+++ b/components/watch-later-queue.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { OptimizedImage } from './optimized-image'
 import { useWatchLater } from '@/hooks/use-watch-later'
-import { navigateToVideo } from '@/lib/pwa-utils'
+import { useWatchLaterQueueActions } from '@/hooks/use-watch-later-queue-actions'
 import type { WatchLaterItem } from '@/lib/watch-later'
 import './watch-later-queue.css'
 
@@ -59,43 +59,25 @@ function WatchLaterItemRow({
 
 export function WatchLaterQueue() {
   const { items, count, removeItem, clearItems, markOpened } = useWatchLater()
+  const {
+    message,
+    openItem,
+    openAndRemove,
+    openFirst,
+    copyAllUrls,
+    clearItems: clearQueuedItems,
+  } = useWatchLaterQueueActions({
+    items,
+    removeItem,
+    clearItems,
+    markOpened,
+  })
   const [isOpen, setIsOpen] = useState(false)
-  const [message, setMessage] = useState('')
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
   }, [])
-
-  const openItem = (item: WatchLaterItem) => {
-    markOpened(item.id)
-    navigateToVideo(item.url)
-  }
-
-  const openAndRemove = (item: WatchLaterItem) => {
-    removeItem(item.id)
-    navigateToVideo(item.url)
-  }
-
-  const openFirst = () => {
-    const first = items[0]
-    if (!first) return
-    openItem(first)
-  }
-
-  const copyAllUrls = async () => {
-    if (items.length === 0) return
-    try {
-      await navigator.clipboard.writeText(
-        items.map((item) => item.url).join('\n'),
-      )
-      setMessage('URLをコピーしました')
-      window.setTimeout(() => setMessage(''), 1800)
-    } catch {
-      setMessage('コピーに失敗しました')
-      window.setTimeout(() => setMessage(''), 1800)
-    }
-  }
 
   const layer = isOpen ? (
     <div className="watch-later-queue__layer" role="presentation">
@@ -164,7 +146,7 @@ export function WatchLaterQueue() {
           </button>
           <button
             type="button"
-            onClick={clearItems}
+            onClick={clearQueuedItems}
             disabled={items.length === 0}
           >
             すべて削除

--- a/hooks/use-watch-later-queue-actions.ts
+++ b/hooks/use-watch-later-queue-actions.ts
@@ -1,0 +1,85 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { navigateToVideo } from '@/lib/pwa-utils'
+import type { WatchLaterItem } from '@/lib/watch-later'
+
+interface UseWatchLaterQueueActionsOptions {
+  items: WatchLaterItem[]
+  removeItem: (videoId: string) => void
+  clearItems: () => void
+  markOpened: (videoId: string) => void
+}
+
+export function useWatchLaterQueueActions({
+  items,
+  removeItem,
+  clearItems,
+  markOpened,
+}: UseWatchLaterQueueActionsOptions) {
+  const [message, setMessage] = useState('')
+  const messageTimerRef = useRef<number | null>(null)
+
+  const showMessage = useCallback((nextMessage: string) => {
+    setMessage(nextMessage)
+    if (messageTimerRef.current) {
+      window.clearTimeout(messageTimerRef.current)
+    }
+    messageTimerRef.current = window.setTimeout(() => {
+      setMessage('')
+      messageTimerRef.current = null
+    }, 1800)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (messageTimerRef.current) {
+        window.clearTimeout(messageTimerRef.current)
+      }
+    }
+  }, [])
+
+  const openItem = useCallback(
+    (item: WatchLaterItem) => {
+      markOpened(item.id)
+      navigateToVideo(item.url)
+    },
+    [markOpened],
+  )
+
+  const openAndRemove = useCallback(
+    (item: WatchLaterItem) => {
+      removeItem(item.id)
+      navigateToVideo(item.url)
+    },
+    [removeItem],
+  )
+
+  const openFirst = useCallback(() => {
+    const first = items[0]
+    if (!first) return
+    openItem(first)
+  }, [items, openItem])
+
+  const copyAllUrls = useCallback(async () => {
+    if (items.length === 0) return
+
+    try {
+      await navigator.clipboard.writeText(
+        items.map((item) => item.url).join('\n'),
+      )
+      showMessage('URLをコピーしました')
+    } catch {
+      showMessage('コピーに失敗しました')
+    }
+  }, [items, showMessage])
+
+  return {
+    message,
+    openItem,
+    openAndRemove,
+    openFirst,
+    copyAllUrls,
+    clearItems,
+  }
+}

--- a/hooks/use-watch-later.ts
+++ b/hooks/use-watch-later.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { RankingItem } from '@/types/ranking'
+import {
+  WATCH_LATER_STORAGE_KEY,
+  WATCH_LATER_UPDATED_EVENT,
+  addWatchLaterItem,
+  clearWatchLaterItems,
+  markWatchLaterItemOpened,
+  readWatchLaterItems,
+  removeWatchLaterItem,
+  type WatchLaterItem,
+  type WatchLaterSource,
+} from '@/lib/watch-later'
+
+export function useWatchLater() {
+  const [items, setItems] = useState<WatchLaterItem[]>(() =>
+    readWatchLaterItems(),
+  )
+
+  const sync = useCallback(() => {
+    setItems(readWatchLaterItems())
+  }, [])
+
+  useEffect(() => {
+    sync()
+
+    const handleUpdate = () => sync()
+    const handleStorage = (event: StorageEvent) => {
+      if (!event.key || event.key === WATCH_LATER_STORAGE_KEY) {
+        sync()
+      }
+    }
+
+    window.addEventListener(WATCH_LATER_UPDATED_EVENT, handleUpdate)
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener(WATCH_LATER_UPDATED_EVENT, handleUpdate)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [sync])
+
+  const addItem = useCallback(
+    (video: RankingItem, source?: WatchLaterSource) => {
+      const result = addWatchLaterItem(video, source)
+      setItems(result.items)
+      return result
+    },
+    [],
+  )
+
+  const removeItem = useCallback((videoId: string) => {
+    setItems(removeWatchLaterItem(videoId))
+  }, [])
+
+  const clearItems = useCallback(() => {
+    setItems(clearWatchLaterItems())
+  }, [])
+
+  const markOpened = useCallback((videoId: string) => {
+    setItems(markWatchLaterItemOpened(videoId))
+  }, [])
+
+  return {
+    items,
+    count: items.length,
+    addItem,
+    removeItem,
+    clearItems,
+    markOpened,
+  }
+}

--- a/lib/watch-later.ts
+++ b/lib/watch-later.ts
@@ -1,0 +1,169 @@
+import type { RankingItem } from '@/types/ranking'
+
+export const WATCH_LATER_STORAGE_KEY = 'watch-later-v1'
+export const WATCH_LATER_UPDATED_EVENT = 'watchLaterUpdated'
+const MAX_WATCH_LATER_ITEMS = 100
+
+export interface WatchLaterSource {
+  genre?: string
+  period?: string
+  tag?: string
+}
+
+export interface WatchLaterItem {
+  id: string
+  title: string
+  thumbURL?: string
+  authorName?: string
+  url: string
+  addedAt: string
+  openedAt?: string
+  sourceGenre?: string
+  sourcePeriod?: string
+  sourceTag?: string
+}
+
+export function getVideoWatchUrl(videoId: string): string {
+  return `https://www.nicovideo.jp/watch/${videoId}`
+}
+
+function canUseStorage(): boolean {
+  try {
+    return (
+      typeof window !== 'undefined' &&
+      typeof window.localStorage !== 'undefined'
+    )
+  } catch {
+    return false
+  }
+}
+
+function normalizeItems(value: unknown): WatchLaterItem[] {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .filter((item): item is WatchLaterItem => {
+      return (
+        item &&
+        typeof item === 'object' &&
+        typeof (item as WatchLaterItem).id === 'string' &&
+        typeof (item as WatchLaterItem).title === 'string'
+      )
+    })
+    .map((item) => {
+      const source = item as Partial<WatchLaterItem>
+      return {
+        id: item.id,
+        title: item.title,
+        thumbURL:
+          typeof source.thumbURL === 'string' ? source.thumbURL : undefined,
+        authorName:
+          typeof source.authorName === 'string' ? source.authorName : undefined,
+        url:
+          typeof source.url === 'string'
+            ? source.url
+            : getVideoWatchUrl(item.id),
+        addedAt:
+          typeof source.addedAt === 'string'
+            ? source.addedAt
+            : new Date().toISOString(),
+        openedAt:
+          typeof source.openedAt === 'string' ? source.openedAt : undefined,
+        sourceGenre:
+          typeof source.sourceGenre === 'string'
+            ? source.sourceGenre
+            : undefined,
+        sourcePeriod:
+          typeof source.sourcePeriod === 'string'
+            ? source.sourcePeriod
+            : undefined,
+        sourceTag:
+          typeof source.sourceTag === 'string' ? source.sourceTag : undefined,
+      }
+    })
+}
+
+export function readWatchLaterItems(): WatchLaterItem[] {
+  if (!canUseStorage()) return []
+
+  try {
+    const raw = window.localStorage.getItem(WATCH_LATER_STORAGE_KEY)
+    if (!raw) return []
+    return normalizeItems(JSON.parse(raw))
+  } catch {
+    return []
+  }
+}
+
+function emitWatchLaterUpdated(items: WatchLaterItem[]): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent(WATCH_LATER_UPDATED_EVENT, {
+      detail: { items },
+    }),
+  )
+}
+
+export function writeWatchLaterItems(
+  items: WatchLaterItem[],
+): WatchLaterItem[] {
+  if (!canUseStorage()) return []
+
+  const normalized = normalizeItems(items).slice(0, MAX_WATCH_LATER_ITEMS)
+  window.localStorage.setItem(
+    WATCH_LATER_STORAGE_KEY,
+    JSON.stringify(normalized),
+  )
+  emitWatchLaterUpdated(normalized)
+  return normalized
+}
+
+export function createWatchLaterItem(
+  video: RankingItem,
+  source?: WatchLaterSource,
+): WatchLaterItem {
+  return {
+    id: video.id,
+    title: video.title,
+    thumbURL: video.thumbURL,
+    authorName: video.authorName,
+    url: getVideoWatchUrl(video.id),
+    addedAt: new Date().toISOString(),
+    sourceGenre: source?.genre,
+    sourcePeriod: source?.period,
+    sourceTag: source?.tag,
+  }
+}
+
+export function addWatchLaterItem(
+  video: RankingItem,
+  source?: WatchLaterSource,
+): { added: boolean; item: WatchLaterItem; items: WatchLaterItem[] } {
+  const current = readWatchLaterItems()
+  const existing = current.find((item) => item.id === video.id)
+
+  if (existing) {
+    return { added: false, item: existing, items: current }
+  }
+
+  const item = createWatchLaterItem(video, source)
+  const items = writeWatchLaterItems([item, ...current])
+  return { added: true, item, items }
+}
+
+export function removeWatchLaterItem(videoId: string): WatchLaterItem[] {
+  const nextItems = readWatchLaterItems().filter((item) => item.id !== videoId)
+  return writeWatchLaterItems(nextItems)
+}
+
+export function clearWatchLaterItems(): WatchLaterItem[] {
+  return writeWatchLaterItems([])
+}
+
+export function markWatchLaterItemOpened(videoId: string): WatchLaterItem[] {
+  const openedAt = new Date().toISOString()
+  const nextItems = readWatchLaterItems().map((item) =>
+    item.id === videoId ? { ...item, openedAt } : item,
+  )
+  return writeWatchLaterItems(nextItems)
+}


### PR DESCRIPTION
## Summary
- Add a localStorage-backed watch later queue for ranking videos
- Add context-menu actions to open videos and add them to the queue
- Add a persistent header queue button with desktop drawer and mobile bottom-sheet behavior
- Separate queue side-effect actions from the UI component for clearer SRP boundaries

## Verification
- npm test -- --run __tests__/unit/watch-later.test.ts __tests__/unit/components/watch-later-queue.test.tsx __tests__/unit/video-context-menu.test.tsx
- npm test -- --run __tests__/unit/components/watch-later-queue.test.tsx
- npm run typecheck -- --pretty false
- npm run lint
- npm run build

## Notes
- lint/build still report existing project warnings only: Sentry disableLogger deprecation, Next turbopack config warning, Next build ESLint option warning, and existing hook/img lint warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Watch Later" feature to save videos for viewing later
  * New header button showing count of queued videos
  * Context menu option to add videos to watch later
  * Watch later panel with options to open, remove, or clear items
  * Copy all watch-later URLs to clipboard
  * Persistent storage of saved videos

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YJSN180/nico-ranking-custom/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->